### PR TITLE
docs: changelog v0.7.5-b2 to v0.8.0-b1, map/heatmap/table title features

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -8,6 +8,110 @@ hide:
 
 # Changelog
 
+## **[v0.8.0-b1](https://github.com/depictio/depictio/releases/tag/v0.8.0-b1)** (February 27, 2026)
+
+!!! warning "Beta Release"
+    This is a beta release. Use in production at your own risk.
+
+### Docker Images
+
+```bash
+ghcr.io/depictio/depictio:0.8.0-b1
+```
+
+### **✨ Features**
+
+* **Geospatial Map Component**: New interactive map component supporting scatter maps (GPS markers), density maps, and choropleth maps (colored regions from GeoJSON). Supports cross-filtering and selection propagation. No API key required (uses Plotly's built-in tile providers).
+* **Choropleth GeoJSON Support**: New `geojson` Data Collection type that loads GeoJSON from S3. Choropleth maps can reference boundaries via URL, Data Collection tag, or inline data.
+* **ComplexHeatmap Integration**: Clustered heatmap with dendrograms and row/column annotations — similar to R's `ComplexHeatmap` — available as native `visu_type: heatmap` via the [:material-open-in-new: plotly-complexheatmap](https://github.com/weber8thomas/plotly-complexheatmap){ target="_blank" } library.
+* **Table Title & Description**: Tables now support configurable `title`, `description`, `title_size` (h1/h2/h3/sm), and `title_align` (left/center/right) in both the stepper UI and YAML format.
+* **Projects Directory Reorganization**: Reference project files reorganized under `depictio/projects/` with a consistent `dashboards/` subdirectory layout for better versioning support.
+
+### **🐛 Bug Fixes**
+
+* Fix map component viewport stability — viewport no longer resets on filter/theme changes
+* Fix map theme switching — promote `theme-store` to Input for reliable dark/light tile swapping
+* Fix map component stepper save support
+
+### **🔧 CI/CD**
+
+* Fix absolute path from `pixi.lock` for CI portability
+* Fix CI `dashboard_lite.yaml` references to new `dashboards/` paths
+
+---
+
+## **[v0.7.6](https://github.com/depictio/depictio/releases/tag/v0.7.6)** (February 26, 2026)
+
+!!! success "Stable Release"
+    This is a stable release consolidating all v0.7.6 beta improvements over v0.7.5.
+
+### Docker Images
+
+```bash
+ghcr.io/depictio/depictio:0.7.6
+```
+
+No user-facing changes — version bump only to promote v0.7.6-b1 to stable.
+
+---
+
+## **[v0.7.6-b1](https://github.com/depictio/depictio/releases/tag/v0.7.6-b1)** (February 25, 2026)
+
+!!! warning "Beta Release"
+    This is a beta release. Use in production at your own risk.
+
+### Docker Images
+
+```bash
+ghcr.io/depictio/depictio:0.7.6-b1
+```
+
+No user-facing changes — version bump only after v0.7.5 stable release.
+
+---
+
+## **[v0.7.5](https://github.com/depictio/depictio/releases/tag/v0.7.5)** (February 25, 2026)
+
+!!! success "Stable Release"
+    This is a stable release consolidating all v0.7.5 beta improvements over v0.7.4.
+
+### Docker Images
+
+```bash
+ghcr.io/depictio/depictio:0.7.5
+```
+
+### **✨ Features**
+
+* **MultiQC General Statistics Table**: New "General Statistics" module option in MultiQC components renders an interactive DataTable from `multiqc.parquet` general stats data. Includes column visibility toggles, search filtering, and theme-aware styling.
+
+### **🐛 Bug Fixes**
+
+* Fix infinite React re-render loop (`Maximum update depth exceeded`) that could occur when multiple interactive components were linked
+
+---
+
+## **[v0.7.5-b2](https://github.com/depictio/depictio/releases/tag/v0.7.5-b2)** (February 25, 2026)
+
+!!! warning "Beta Release"
+    This is a beta release. Use in production at your own risk.
+
+### Docker Images
+
+```bash
+ghcr.io/depictio/depictio:0.7.5-b2
+```
+
+### **✨ Features**
+
+* **MultiQC General Statistics Table**: New "General Statistics" module option in MultiQC components renders an interactive DataTable from `multiqc.parquet` general stats data. Includes column visibility toggles, search filtering, and theme-aware styling.
+
+### **🐛 Bug Fixes**
+
+* Fix infinite React re-render loop (`Maximum update depth exceeded`) that could occur when multiple interactive components were linked
+
+---
+
 ## **[v0.7.5-b1](https://github.com/depictio/depictio/releases/tag/v0.7.5-b1)** (February 25, 2026)
 
 !!! warning "Beta Release"

--- a/docs/features/components.md
+++ b/docs/features/components.md
@@ -187,6 +187,10 @@ Table components display data in interactive tables with built-in filtering and 
 | Visible Columns | Columns to display | All columns |
 | Page Size | Rows per page | 10, 25, 50, or 100 |
 | Style | Column width, text alignment | Auto |
+| Title | Header text above the table | Auto (from DC tag) |
+| Description | Subtitle text below the title | None |
+| Title Size | Header level: `h1`, `h2`, `h3`, or `sm` | `sm` |
+| Title Align | Text alignment: `left`, `center`, or `right` | `left` |
 
 ### Row Selection Filtering
 

--- a/docs/features/cross-dc-filtering.md
+++ b/docs/features/cross-dc-filtering.md
@@ -80,6 +80,7 @@ Resolvers map source values to target identifiers:
 |------|---------------|--------|
 | :material-table: `table` | Filters rows with `WHERE IN` | :material-check: Available |
 | :material-microscope: `multiqc` | Filters plot samples | :material-check: Available |
+| :material-map-marker-multiple: `map` | Filters map markers | :material-check: Available |
 | :material-dna: `jbrowse2` | Shows/hides tracks | :material-clock-outline: Planned |
 | :material-image-multiple: `images` | Filters image gallery | :material-clock-outline: Planned |
 

--- a/docs/features/data-model.md
+++ b/docs/features/data-model.md
@@ -131,6 +131,7 @@ An **aggregated view of output files** from one or more runs, typed by content.
 | `table` | Tabular data (CSV/TSV/Parquet → Delta Lake) |
 | `multiqc` | MultiQC JSON report files |
 | `image` | Image files (PNG, SVG, …) |
+| `geojson` | GeoJSON boundary files for choropleth maps |
 
 DataCollections also carry a **source** attribute describing how they were created:
 

--- a/docs/features/interactive-selection-filtering.md
+++ b/docs/features/interactive-selection-filtering.md
@@ -15,6 +15,7 @@ Filter dashboard components by selecting points on scatter plots or rows in tabl
 - :material-chart-scatter-plot: **Lasso or box-select** points on scatter plots
 - :material-gesture-tap: **Click** individual points on scatter plots
 - :material-table-row: **Select rows** in AG Grid tables
+- :material-map-marker-multiple: **Lasso or click** markers on scatter maps
 
 Selected values automatically filter other components on the same Data Collection.
 
@@ -115,6 +116,26 @@ components:
 ### Reset Selection
 
 Click the :material-refresh: **Reset** button on the table to clear row selection.
+
+---
+
+## :material-map-marker-multiple: Map Selection
+
+Scatter maps support the same selection modes as scatter plots (lasso, box, click). Add `selection_enabled` and `selection_column` to a map component:
+
+```yaml
+- tag: sampling-map
+  component_type: map
+  workflow_tag: python/my_workflow
+  data_collection_tag: sample_metadata
+  lat_column: latitude
+  lon_column: longitude
+  color_column: biome
+  selection_enabled: true
+  selection_column: sample_id
+```
+
+Selected markers dim unselected points and filter other components on the same Data Collection. Choropleth maps do not support selection.
 
 ---
 
@@ -233,7 +254,7 @@ components:
 ## :material-alert-circle-outline: Limitations
 
 - **Same Data Collection**: Selection filtering works within the same Data Collection. For cross-DC filtering, use [Links](cross-dc-filtering.md).
-- **Scatter Only**: Currently only scatter plots support selection (not bar charts, histograms, etc.).
+- **Scatter & Maps Only**: Currently scatter plots and scatter maps support selection (not bar charts, histograms, or choropleth maps).
 - **No Persistence**: Selections are cleared on page reload.
 
 ---

--- a/docs/features/yaml-sync.md
+++ b/docs/features/yaml-sync.md
@@ -202,7 +202,7 @@ project_tag: Project_Name
 
 components:
   - tag: component-identifier
-    component_type: figure|card|interactive|table|image|multiqc
+    component_type: figure|card|interactive|table|image|multiqc|map
     workflow_tag: engine/workflow_name
     data_collection_tag: dc_tag
     # Component-specific fields...
@@ -323,7 +323,7 @@ components:
 | `figure`      | Plotly charts (scatter, box, heatmap, etc.)    | `visu_type` (ui mode) or `code_content` (code mode)     |
 | `card`        | Metric cards with aggregations                 | `aggregation`, `column_name`                             |
 | `interactive` | Filters (RangeSlider, MultiSelect, etc.)       | `interactive_component_type`, `column_name`              |
-| `table`       | Data tables                                    | _(none beyond base fields)_                              |
+| `table`       | Data tables                                    | _(none required — title auto-generated from DC tag)_     |
 | `image`       | Image galleries from S3/MinIO                  | `image_column`                                           |
 | `multiqc`     | MultiQC quality control report viewer          | `selected_module`, `selected_plot`                       |
 | `map`         | Geospatial maps (scatter, density, choropleth) | `lat_column`, `lon_column` (scatter/density) or `locations_column`, GeoJSON source (choropleth) |
@@ -488,9 +488,15 @@ Heatmap `dict_kwargs` parameters:
   component_type: table
   workflow_tag: python/workflow_name
   data_collection_tag: table_dc
-  page_size: 25          # rows per page (default: 10)
-  columns: [col1, col2]  # optional: restrict visible columns
+  page_size: 25            # rows per page (default: 10)
+  columns: [col1, col2]   # optional: restrict visible columns
+  title: "Sample Data"    # optional: auto-generated from DC tag if omitted
+  description: "Complete measurements across all samples"  # optional subtitle
+  title_size: h3          # h1, h2, h3, or sm (default: sm)
+  title_align: left       # left (default), center, or right
 ```
+
+**Title / description** fields are rendered as a header above the AG Grid table. When `title` is omitted, it is auto-generated from `data_collection_tag`.
 
 ### Image Component
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,15 @@ hide:
         <h4>Image</h4>
         <p>Image galleries with S3/MinIO storage integration</p>
       </div>
+      <div class="component-card">
+        <div class="component-icon" style="background: var(--depictio-violet);">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12,11.5A2.5,2.5 0 0,1 9.5,9A2.5,2.5 0 0,1 12,6.5A2.5,2.5 0 0,1 14.5,9A2.5,2.5 0 0,1 12,11.5M12,2A7,7 0 0,0 5,9C5,14.25 12,22 12,22C12,22 19,14.25 19,9A7,7 0 0,0 12,2Z"/>
+          </svg>
+        </div>
+        <h4>Map</h4>
+        <p>Geospatial map visualization with markers</p>
+      </div>
     </div>
   </div>
 </section>
@@ -992,8 +1001,9 @@ hide:
   }
 
   .components-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 1.5rem;
     max-width: 900px;
     margin: 0 auto;
@@ -1007,6 +1017,8 @@ hide:
     border: 1px solid var(--md-default-fg-color--lightest);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     text-align: center;
+    width: calc((100% - 3rem) / 3);
+    box-sizing: border-box;
   }
 
   [data-md-color-scheme="slate"] .component-card {
@@ -1059,8 +1071,8 @@ hide:
   }
 
   @media (max-width: 900px) {
-    .components-grid {
-      grid-template-columns: repeat(2, 1fr);
+    .component-card {
+      width: calc((100% - 1.5rem) / 2);
     }
   }
 
@@ -1072,8 +1084,8 @@ hide:
   }
 
   @media (max-width: 500px) {
-    .components-grid {
-      grid-template-columns: 1fr;
+    .component-card {
+      width: 100%;
     }
   }
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -34,6 +34,12 @@ hide:
   key: "completed"
   sub_title: "Phase 2: Specialization ✅"
 
+- title: "Geospatial Map Component"
+  content: "Scatter, density, and choropleth maps with cross-filtering and GeoJSON data collection support"
+  icon: ":fontawesome-solid-map-location-dot:"
+  key: "completed"
+  sub_title: "Phase 2: Specialization ✅"
+
 - title: "Templates & Community"
   content: "Reusable dashboard templates for standard bioinformatics workflows, nf-core integration, and nf-core plugin for automatic data ingestion"
   icon: "./nf-core-logo-square.png"
@@ -96,13 +102,14 @@ Depictio is built with [FAIR principles](https://www.go-fair.org/fair-principles
 - [x] Generic components: Figure, Table, Card, Interactive ([docs](../features/components.md))
 - [x] MultiQC components for QC reports ([docs](../features/components.md#multiqc-components))
 - [x] Image grid with S3/MinIO integration and configurable thumbnails ([:material-github: #664](https://github.com/depictio/depictio/pull/664))
+- [x] Geospatial map component: scatter, density, choropleth with GeoJSON DC support ([docs](../features/components.md#map-components))
 - [x] Figure code mode with live preview ([:material-github: #639](https://github.com/depictio/depictio/pull/639))
 
 ### Dashboard Interactivity
 
 - [x] Two-panel layout with tabs ([:material-github: #616](https://github.com/depictio/depictio/pull/616))
 - [x] Cross-DC filtering via universal linking ([docs](../features/cross-dc-filtering.md))
-- [x] Interactive selection filtering: scatter/table selections
+- [x] Interactive selection filtering: scatter/table/map selections
 - [x] YAML dashboard import/export ([docs](../features/yaml-sync.md))
 
 ### Infrastructure

--- a/docs/usage/projects/reference.md
+++ b/docs/usage/projects/reference.md
@@ -134,8 +134,11 @@ workflows:
           # Required: Type of data collection
           type:
             "table" # Required: Data collection type
-            # Options (only table for now):
+            # Options:
             #   "table" - Tabular data (CSV, TSV, Excel, Parquet, Feather)
+            #   "MultiQC" - MultiQC quality control reports
+            #   "Image" - Image files with metadata
+            #   "geojson" - GeoJSON boundary files for choropleth maps
 
           # Required: Data aggregation strategy
           metatype:
@@ -270,6 +273,38 @@ workflows:
         #       target_type: "multiqc"
         #       link_config:
         #         resolver: "sample_mapping"
+
+      # --- GeoJSON DATA COLLECTION ---
+      - data_collection_tag:
+          "europe_geojson" # Required: Unique identifier for GeoJSON data
+
+        description:
+          "GeoJSON boundaries for European regions" # Optional: Description
+
+        config:
+          # Required: Type specification for GeoJSON
+          type:
+            "geojson" # Required: Identifies this as a GeoJSON data collection
+            # NOTE: GeoJSON type stores FeatureCollection files in S3
+            #   - Used as boundary source for choropleth_map components
+            #   - Referenced by geojson_dc_tag in dashboard YAML
+            #   - Requires a single .geojson file
+
+          metatype:
+            "GeoJSON" # Required: Metatype identifier
+
+          # Required: File discovery configuration
+          scan:
+            mode: single
+            scan_parameters:
+              filename: "path/to/boundaries.geojson"
+
+          # Required: GeoJSON-specific configuration
+          dc_specific_properties:
+            feature_id_key:
+              "properties.NAME" # Required: GeoJSON property path to match locations_column
+              # Maps to Plotly's featureidkey parameter
+              # Common values: "id", "properties.NAME", "properties.ISO_A3"
 ```
 
 ## See Also

--- a/docs/usage/projects/yaml-examples.md
+++ b/docs/usage/projects/yaml-examples.md
@@ -328,8 +328,11 @@ data_collections:
 
     config:                     # Required: Data collection configuration
       type: string                # Required: Data collection type
-                                  # Options (only table for now):
+                                  # Options:
                                   #  - "table": Tabular data (CSV, TSV, Excel, Parquet, Feather)
+                                  #  - "MultiQC": MultiQC quality control reports
+                                  #  - "Image": Image files with metadata
+                                  #  - "geojson": GeoJSON boundary files for choropleth maps
 
       metatype: string | null    # Required for table type
                                   # Required: Data collection metatype
@@ -368,7 +371,7 @@ data_collections:
 ### Specific Data Collection Types
 
 !!! note "Data Collection Types"
-    Data collections can be of different types, each with its own configuration requirements. Currently, only the "table" type is supported, which handles structured tabular data. Future versions may introduce additional types for other data formats (e.g., Omics data, Images, GeoJSON).
+    Data collections can be of different types, each with its own configuration requirements. Supported types: **Table** (structured tabular data), **MultiQC** (quality control reports), **Image** (image galleries), and **GeoJSON** (boundary files for choropleth maps).
 
 #### **Table** Data Collection Configuration
 
@@ -421,6 +424,40 @@ config:
   # - MultiQC 1.29+ must be used to generate parquet format
   # - Each run directory must contain: multiqc_data/multiqc.parquet
 ```
+
+#### **GeoJSON** Data Collection Configuration
+
+GeoJSON data collections store boundary files (FeatureCollections) used as the geometry source for choropleth map components:
+
+```yaml
+config:
+  # === REQUIRED FIELDS ===
+
+  type: "geojson"          # Required: Identifies this as a GeoJSON data collection
+
+  metatype: "GeoJSON"      # Required: Metatype identifier
+
+  scan:                    # Required: File discovery
+    mode: "single"
+    scan_parameters:
+      filename: "path/to/boundaries.geojson"
+
+  dc_specific_properties:
+    feature_id_key: "properties.NAME"  # Required: GeoJSON property path
+                                       # to match the locations_column
+                                       # in choropleth map components
+                                       # Common values: "id", "properties.NAME",
+                                       #   "properties.ISO_A3"
+```
+
+**GeoJSON-Specific Notes:**
+
+- **Purpose**: Provides region boundaries for `choropleth_map` components
+- **Dashboard Reference**: Referenced via `geojson_dc_tag` in dashboard YAML
+- **File Format**: Standard GeoJSON FeatureCollection (`.geojson`)
+- **Feature ID Key**: Maps to Plotly's `featureidkey` parameter — identifies which GeoJSON property matches the `locations_column` in your tabular data
+
+---
 
 **Linking MultiQC with Metadata (Recommended):**
 


### PR DESCRIPTION
## Summary

- Add missing changelog entries for v0.7.5-b2, v0.7.5, v0.7.6-b1, v0.7.6, and v0.8.0-b1
- Document new features: geospatial map component (scatter/density/choropleth), ComplexHeatmap integration, table title/description/styling, GeoJSON data collection type
- Update components, YAML sync, cross-DC filtering, interactive selection, data model, project reference, index page, and roadmap

## Changes

| File | What changed |
|------|-------------|
| `changelog/README.md` | 5 new version entries (v0.7.5-b2 through v0.8.0-b1) |
| `features/components.md` | Table title/description/styling config options |
| `features/yaml-sync.md` | Table YAML fields (title, description, title_size, title_align), map in component_type |
| `features/data-model.md` | GeoJSON DC type in data model table |
| `features/cross-dc-filtering.md` | Map component in supported targets |
| `features/interactive-selection-filtering.md` | Map selection section, updated limitations |
| `usage/projects/reference.md` | GeoJSON DC type full reference |
| `usage/projects/yaml-examples.md` | GeoJSON DC example + updated type list |
| `index.md` | Map component card on landing page, grid layout fix for 7 items |
| `roadmap/README.md` | Geospatial map milestone + map in selection filtering |

## Test plan

- [ ] `mkdocs build` passes (verified by pre-commit hook)
- [ ] Markdownlint passes (verified by pre-commit hook)
- [ ] Visual review of changelog, components, and YAML sync pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)