### PR TITLE
docs: add Administration section, sidebar icons, and migrate/backup reference pages

### DIFF
--- a/docs/depictio-cli/index.md
+++ b/docs/depictio-cli/index.md
@@ -1,0 +1,16 @@
+---
+title: CLI
+icon: material/console
+description: Command-line tools for data ingestion, recipes, and templates.
+---
+
+# :material-console: CLI
+
+Command-line tools for data ingestion, recipes, and templates.
+
+| Page | Description |
+|------|-------------|
+| [Usage](usage.md) | All CLI commands with options and examples |
+| [Minimal YAML Config](minimal_config.md) | Minimal project YAML to get started |
+| [Recipes](../usage/projects/recipes.md) | Data transformation recipes for bioinformatics pipelines |
+| [Templates](../usage/projects/templates.md) | One-command project setup for nf-core pipelines |

--- a/docs/depictio-cli/usage.md
+++ b/docs/depictio-cli/usage.md
@@ -11,6 +11,7 @@
 - [Global Options](#global-options)
 - [🚀 Commands](#-commands)
   - [🏃 Run Command](#run-command)
+  - [🍳 Recipe Commands](#recipe-commands)
   - [📋 Config Commands](#config-commands)
   - [📊 Data Commands](#data-commands)
   - [📈 Dashboard Commands](#dashboard-commands)
@@ -29,6 +30,9 @@ See the [installation guide](../installation/cli.md) for instructions on how to 
 | -------------------------------------- | --------------------------------------- | -------------- |
 | `version`                              | Show CLI version                        | All users      |
 | `run`                                  | Execute complete workflow               | All users      |
+| `recipe list`                          | List all bundled recipes                | All users      |
+| `recipe info <name>`                   | Show recipe sources and schema          | All users      |
+| `recipe run <name>`                    | Execute a recipe locally with validation| All users      |
 | `config show-cli-config`               | Display CLI configuration               | All users      |
 | `config check-s3-storage`              | Validate S3 storage setup               | All users      |
 | `config check-server-accessibility`    | Test server connection                  | All users      |
@@ -44,7 +48,7 @@ See the [installation guide](../installation/cli.md) for instructions on how to 
 | `backup validate`                      | Validate backup against models          | **Admin only** |
 | `backup restore`                       | Restore from backup                     | **Admin only** |
 | `backup check-coverage`                | Check validation coverage               | **Admin only** |
-| `migrate run`                          | Migrate a project to another instance   | **Admin only** |
+| `migrate`                          | Migrate a project to another instance   | **Admin only** |
 
 <!-- | Command                                | Description                             | Access Level   |
 | -------------------------------------- | --------------------------------------- | -------------- |
@@ -111,9 +115,23 @@ depictio-cli run --project-config-path ./config.yaml
     | Parameter | Type | Default | Description |
     |-----------|------|---------|-------------|
     | `--CLI-config-path` | `string` | `~/.depictio/CLI.yaml` | CLI configuration file path |
-    | `--project-config-path` | `string` | `""` | Pipeline configuration file path |
+    | `--project-config-path` | `string` | `""` | Pipeline configuration file path (mutually exclusive with `--template`) |
     | `--workflow-name` | `string` | `null` | Specific workflow to process |
     | `--data-collection-tag` | `string` | `null` | Data collection tag to process |
+
+??? info "🍳 Template Options"
+
+    Use these flags to run from a pre-packaged template instead of a project YAML. `--template` and `--project-config-path` are mutually exclusive.
+
+    | Parameter | Type | Default | Description |
+    |-----------|------|---------|-------------|
+    | `--template` | `string` | `null` | Template ID (e.g. `nf-core/ampliseq/2.16.0`) |
+    | `--data-root` | `path` | `null` | Root directory substituted for `{DATA_ROOT}` in template. Required when `--template` is set. |
+    | `--project-name` | `string` | `null` | Custom project name (auto-generated from template if omitted) |
+    | `--dashboard` | `path` | `null` | Override default dashboard(s) to import. Repeatable. |
+    | `--skip-dashboard-import` | `flag` | `false` | Skip the automatic dashboard import step (Step 8) |
+
+    See [Templates](../usage/projects/templates.md) for full documentation.
 
 ??? info "⚙️ Flow Control Options"
 
@@ -151,6 +169,15 @@ depictio-cli run --project-config-path ./config.yaml
 depictio-cli run --project-config-path ./config.yaml
 ```
 
+=== "Template (nf-core/ampliseq)"
+
+```bash
+# Set up a complete ampliseq project from raw pipeline output
+depictio-cli run \
+  --template nf-core/ampliseq/2.16.0 \
+  --data-root /data/my_ampliseq_run
+```
+
 === "Development"
 
 ```bash
@@ -178,6 +205,95 @@ depictio-cli run \
   --project-config-path ./config.yaml \
   --skip-server-check \
   --skip-s3-check
+```
+
+### 🍳 Recipe Commands
+
+<!-- prettier-ignore -->
+!!! info "Command Group: `depictio-cli recipe`"
+    All commands in this section are part of the `recipe` command family. Use them to discover, inspect, and locally test data transformation recipes before running them in a project. For full recipe documentation, see [Recipes](../usage/projects/recipes.md).
+
+Discover and execute data transformation recipes locally.
+
+#### `recipe list`
+
+List all bundled recipes.
+
+```bash
+depictio-cli recipe list
+```
+
+**Output:**
+
+```
+Available recipes (5):
+  nf-core/ampliseq/alpha_diversity.py
+  nf-core/ampliseq/alpha_rarefaction.py
+  nf-core/ampliseq/ancombc.py
+  nf-core/ampliseq/taxonomy_composition.py
+  nf-core/ampliseq/taxonomy_rel_abundance.py
+```
+
+---
+
+#### `recipe info <name>`
+
+Show recipe details: description, sources, and expected output schema.
+
+```bash
+depictio-cli recipe info <recipe_name>
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `recipe_name` | `string` | **required** | Recipe name (e.g. `nf-core/ampliseq/alpha_diversity.py`) |
+
+```bash
+depictio-cli recipe info nf-core/ampliseq/alpha_diversity.py
+```
+
+**Output:**
+
+```
+Recipe: nf-core/ampliseq/alpha_diversity.py
+Description: Transform QIIME2 alpha diversity vector to per-sample Faith PD table.
+
+Sources (1):
+  faith_pd: qiime2/diversity/alpha_diversity/faith_pd_vector/metadata.tsv (TSV)
+
+Expected output schema (3 columns):
+  sample: Utf8
+  habitat: Utf8
+  faith_pd: Float64
+```
+
+---
+
+#### `recipe run <name>`
+
+Execute a recipe against a local data directory with all 4 validation checkpoints.
+
+```bash
+depictio-cli recipe run <recipe_name> [OPTIONS]
+```
+
+| Parameter | Short | Default | Description |
+|-----------|-------|---------|-------------|
+| `recipe_name` | — | **required** | Recipe name (e.g. `nf-core/ampliseq/alpha_diversity.py`) |
+| `--data-dir` | `-d` | **required** | Root directory with workflow output files |
+| `--output` | `-o` | `null` | Save result to `.parquet` or `.csv` file |
+| `--head` | `-n` | `20` | Number of rows to display |
+
+```bash
+# Run with validation output
+depictio-cli recipe run nf-core/ampliseq/alpha_diversity.py \
+  --data-dir /data/ampliseq_results
+
+# Save output and show first 5 rows
+depictio-cli recipe run nf-core/ampliseq/alpha_diversity.py \
+  --data-dir /data/ampliseq_results \
+  --output alpha_diversity.parquet \
+  --head 5
 ```
 
 ### 📋 Config Commands
@@ -621,12 +737,12 @@ depictio-cli backup check-coverage
 !!! warning "Admin Access Required"
     All migrate operations require administrator privileges on both the source and target instances.
 
-#### `migrate run`
+#### `migrate`
 
 Migrate a project from one Depictio instance to another — non-destructive upsert, never wipes existing data on the target.
 
 ```bash
-depictio-cli migrate run --project <name> [OPTIONS]
+depictio-cli migrate --project <name> [OPTIONS]
 ```
 
 | Parameter           | Type     | Default                     | Description                                        |
@@ -648,27 +764,27 @@ depictio-cli migrate run --project <name> [OPTIONS]
 
 ```bash
 # Dry-run first (recommended before any migration)
-depictio-cli migrate run \
+depictio-cli migrate \
   --project "My Project" \
   --CLI-config-path ~/.depictio/CLI_local.yaml \
   --target-config ~/.depictio/CLI_remote.yaml \
   --dry-run
 
 # Full migration (MongoDB + S3)
-depictio-cli migrate run \
+depictio-cli migrate \
   --project "My Project" \
   --CLI-config-path ~/.depictio/CLI_local.yaml \
   --target-config ~/.depictio/CLI_remote.yaml
 
 # Metadata-only (shared S3)
-depictio-cli migrate run \
+depictio-cli migrate \
   --project "My Project" \
   --CLI-config-path ~/.depictio/CLI_local.yaml \
   --target-config ~/.depictio/CLI_remote.yaml \
   --mode metadata
 
 # Dashboard-only update
-depictio-cli migrate run \
+depictio-cli migrate \
   --project "My Project" \
   --CLI-config-path ~/.depictio/CLI_local.yaml \
   --target-config ~/.depictio/CLI_remote.yaml \
@@ -788,14 +904,14 @@ depictio-cli run --project-config-path ./config.yaml --update-config --overwrite
 
 ```bash
 # 1. Dry-run to preview what will be migrated
-depictio-cli migrate run \
+depictio-cli migrate \
   --project "My Project" \
   --CLI-config-path ~/.depictio/CLI_local.yaml \
   --target-config ~/.depictio/CLI_remote.yaml \
   --dry-run
 
 # 2. Run full migration (MongoDB docs + S3 files)
-depictio-cli migrate run \
+depictio-cli migrate \
   --project "My Project" \
   --CLI-config-path ~/.depictio/CLI_local.yaml \
   --target-config ~/.depictio/CLI_remote.yaml
@@ -805,7 +921,7 @@ depictio-cli migrate run \
 
 ```bash
 # When source and target share the same S3, only migrate MongoDB docs
-depictio-cli migrate run \
+depictio-cli migrate \
   --project "My Project" \
   --CLI-config-path ~/.depictio/CLI_local.yaml \
   --target-config ~/.depictio/CLI_remote.yaml \
@@ -817,7 +933,7 @@ depictio-cli migrate run \
 ```bash
 # Push updated dashboard layouts to a remote instance
 # (project and data already exist on remote)
-depictio-cli migrate run \
+depictio-cli migrate \
   --project "My Project" \
   --CLI-config-path ~/.depictio/CLI_local.yaml \
   --target-config ~/.depictio/CLI_remote.yaml \

--- a/docs/depictio-cli/usage.md
+++ b/docs/depictio-cli/usage.md
@@ -15,6 +15,7 @@
   - [📊 Data Commands](#data-commands)
   - [📈 Dashboard Commands](#dashboard-commands)
   - [💾 Backup Commands](#backup-commands)
+  - [🔄 Migrate Commands](#migrate-commands)
 - [🛠️ Common Use Cases](#common-use-cases)
 <!-- - [🔧 Error Handling](#error-handling) -->
 
@@ -43,6 +44,7 @@ See the [installation guide](../installation/cli.md) for instructions on how to 
 | `backup validate`                      | Validate backup against models          | **Admin only** |
 | `backup restore`                       | Restore from backup                     | **Admin only** |
 | `backup check-coverage`                | Check validation coverage               | **Admin only** |
+| `migrate run`                          | Migrate a project to another instance   | **Admin only** |
 
 <!-- | Command                                | Description                             | Access Level   |
 | -------------------------------------- | --------------------------------------- | -------------- |
@@ -613,6 +615,66 @@ depictio-cli backup check-coverage [OPTIONS]
 depictio-cli backup check-coverage
 ```
 
+### 🔄 Migrate Commands
+
+<!-- prettier-ignore -->
+!!! warning "Admin Access Required"
+    All migrate operations require administrator privileges on both the source and target instances.
+
+#### `migrate run`
+
+Migrate a project from one Depictio instance to another — non-destructive upsert, never wipes existing data on the target.
+
+```bash
+depictio-cli migrate run --project <name> [OPTIONS]
+```
+
+| Parameter           | Type     | Default                     | Description                                        |
+| ------------------- | -------- | --------------------------- | -------------------------------------------------- |
+| `--project`         | `string` | **required**                | Project name to migrate                            |
+| `--CLI-config-path` | `string` | `~/.depictio/CLI.yaml`      | Source instance CLI config (credentials + API URL) |
+| `--target-config`   | `string` | `~/.depictio/CLI_remote.yaml` | Target instance CLI config                       |
+| `--mode`            | `string` | `all`                       | Migration scope: `all`, `metadata`, `dashboard`, `files` |
+| `--dry-run`         | `flag`   | `False`                     | Preview changes without writing anything           |
+
+**Migration modes:**
+
+| Mode        | What is migrated                                  | When to use                                         |
+| ----------- | ------------------------------------------------- | --------------------------------------------------- |
+| `all`       | MongoDB documents + S3 files                      | First-time full migration                           |
+| `metadata`  | MongoDB documents only                            | Both instances share the same S3 storage            |
+| `dashboard` | Dashboard documents only                          | Project already exists on remote, updating layouts  |
+| `files`     | S3 files only                                     | MongoDB already migrated, syncing data files        |
+
+```bash
+# Dry-run first (recommended before any migration)
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml \
+  --dry-run
+
+# Full migration (MongoDB + S3)
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml
+
+# Metadata-only (shared S3)
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml \
+  --mode metadata
+
+# Dashboard-only update
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml \
+  --mode dashboard
+```
+
 ## 🛠️ Common Use Cases
 
 ### 🚀 Quick Start
@@ -714,6 +776,52 @@ depictio-cli data process --project-config-path ./config.yaml --overwrite
 
 # Update and reprocess
 depictio-cli run --project-config-path ./config.yaml --update-config --overwrite
+```
+
+### 🔄 Project Migration
+
+<!-- prettier-ignore -->
+!!! warning "Admin Access Required"
+    Migration requires administrator privileges on both source and target instances.
+
+=== "First-time Migration"
+
+```bash
+# 1. Dry-run to preview what will be migrated
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml \
+  --dry-run
+
+# 2. Run full migration (MongoDB docs + S3 files)
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml
+```
+
+=== "Shared S3 Storage"
+
+```bash
+# When source and target share the same S3, only migrate MongoDB docs
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml \
+  --mode metadata
+```
+
+=== "Dashboard Update"
+
+```bash
+# Push updated dashboard layouts to a remote instance
+# (project and data already exist on remote)
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml \
+  --mode dashboard
 ```
 
 ## 📖 Configuration References

--- a/docs/features/migrate.md
+++ b/docs/features/migrate.md
@@ -1,0 +1,109 @@
+# Project Migration
+
+Depictio supports **non-destructive project migration** between instances — move a project (MongoDB metadata + S3 data files) from one Depictio deployment to another without touching any other project on the target.
+
+## Overview
+
+Migration works as a scoped upsert: every document is written via `ReplaceOne(..., upsert=True)`, so:
+
+- Re-running migration is idempotent — no duplicates are created.
+- Only the migrated project's documents are affected — all other projects on the target remain untouched.
+- Owner IDs that do not exist on the target are remapped to the importing admin user.
+
+## How It Works
+
+```
+Source instance                        Target instance
+─────────────────                      ─────────────────
+depictio-cli                           API: /migrate/import-project
+    │                                       │
+    ├─ api_export_project()                 ├─ Upsert: projects
+    │     └─ POST /migrate/export-project   ├─ Upsert: workflows
+    │           → ZIP bundle               ├─ Upsert: data_collections
+    │             ├─ bundle.json           ├─ Upsert: files / deltatables / runs
+    │             └─ migrate_metadata.json └─ Upsert: dashboards
+    │
+    └─ (optionally) copy S3 files
+          source MinIO → target MinIO
+```
+
+The export endpoint returns a **ZIP archive** containing:
+
+- `bundle.json` — all MongoDB documents for the project (projects, workflows, data_collections, files, deltatables, runs, dashboards)
+- `migrate_metadata.json` — export timestamp, project name, mode, document counts
+
+## Migration Modes
+
+| Mode        | MongoDB docs | S3 files | Typical use case                              |
+| ----------- | :----------: | :------: | --------------------------------------------- |
+| `all`       | ✅           | ✅       | First-time full migration                     |
+| `metadata`  | ✅           | ❌       | Both instances share the same S3 bucket       |
+| `dashboard` | dashboards only | ❌    | Project exists on remote, updating layouts    |
+| `files`     | ❌           | ✅       | MongoDB already migrated, syncing data files  |
+
+## CLI Usage
+
+See [CLI Reference — migrate run](../depictio-cli/usage.md#migrate-commands) for the full option reference.
+
+```bash
+# Recommended: dry-run first
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml \
+  --dry-run
+
+# Full migration
+depictio-cli migrate run \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml
+```
+
+Each config file points to a different Depictio instance and carries its own API URL, token, and S3 credentials.
+
+## Web UI
+
+Migration is also available directly from the Projects page — no CLI required.
+
+### Export a Project
+
+1. Open **Projects** (`/projects`).
+2. Expand the project you want to export.
+3. Open the **Project Management** accordion section.
+4. Click **Export Project** (violet button).
+5. A `.zip` file downloads automatically — this is the same bundle the CLI produces.
+
+### Import a Project
+
+1. Click **Create New Project**.
+2. Switch to the **Import** tab.
+3. Drag-and-drop (or browse for) the `.zip` bundle.
+4. A preview shows the project name, export mode, and document counts.
+5. Click **Import Project** — the project is created and owned by your account.
+
+<!-- prettier-ignore -->
+!!! note "Owner remapping"
+    When importing via the UI, all project and dashboard owners in the bundle are automatically remapped to the importing user. This differs from the CLI, which only remaps owners that do not already exist on the target instance.
+
+## S3 Data Scope
+
+When `mode=all` or `mode=files`, the migrate feature copies S3 objects for all supported data collection types:
+
+| Data Collection Type | S3 location source                                        |
+| -------------------- | --------------------------------------------------------- |
+| Delta Lake / Table   | `deltatables.delta_table_location`                        |
+| GeoJSON              | `data_collections.config.dc_specific_properties.s3_location` |
+| Image                | `data_collections.config.dc_specific_properties.s3_base_folder` |
+| MultiQC              | `multiqc_reports.s3_location`                             |
+| JBrowse2             | S3 URIs in `jbrowse_collection.tracks[].uri`              |
+
+S3 objects are streamed directly from source to target (no full buffering in RAM).
+
+## Permissions
+
+Both the CLI and UI require **administrator** privileges:
+
+- **CLI**: both source and target configs must authenticate as admins.
+- **UI export**: the user must be admin (or project owner).
+- **UI import**: the user must be admin; all document owners are remapped to the importing user.

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -6,47 +6,176 @@ description: "Learn how to use Depictio to create interactive dashboards and vis
 
 # Usage
 
-This section provides guidance on how to effectively use Depictio to create and manage interactive dashboards for visualizing bioinformatics data.
+This section provides step-by-step guidance on how to use Depictio — from first login to advanced CLI workflows.
 
-## Getting Started
+---
 
-After installing Depictio, you can begin by:
+## :material-rocket-launch: Getting Started
 
-- Accessing the web interface
-- Setting up your first project
-- Creating your first dashboard
-- Ingesting data using the CLI tool
+New to Depictio? Start here.
 
-For a step-by-step introduction, see the [Getting Started Guide](get_started.md).
+<div class="grid cards" markdown>
 
-## Key steps
+-   :material-play-circle:{ .lg .middle } **Get Started**
 
-Depictio supports several key steps:
+    ---
 
-1. **Data Ingestion** - Import your data into Depictio using the CLI tool
-2. **Project Management** - Organize your data into projects
-3. **Dashboard Creation** - Design interactive dashboards to visualize your data
-4. **Data Exploration** - Interact with your data through filters and selections
-5. **Sharing** - Share your dashboards with collaborators in the same Depictio instance (for now)
+    First login, project creation, and your first dashboard in minutes
 
-## Available Guides
+    [:octicons-arrow-right-24: Getting Started Guide](get_started.md)
 
-Explore our detailed guides to learn more about specific aspects of Depictio:
+</div>
 
-- [Web UI Guide](guides/web_ui.md) - Navigate and use the Depictio web interface
-- [Dashboard Creation Guide](guides/dashboard_creation.md) - Create and configure dashboards
-- [Dashboard Usage Guide](guides/dashboard_usage.md) - Interact with and explore dashboards
-- [Unauthenticated Mode Guide](guides/unauthenticated_mode.md) - Use Depictio without authentication for quick access
+---
 
-## CLI Tool
+## :material-book-open-variant: Guides
 
-The Depictio CLI tool is essential for data ingestion and management. Learn how to use it effectively:
+Hands-on guides for common tasks in the web interface.
 
-- [CLI Usage Guide](../depictio-cli/usage.md) - Basic and advanced CLI commands
-- [YAML Configuration Reference](../depictio-cli/full_reference_config.md) - Configure the CLI tool
+| Page | Description |
+|------|-------------|
+| [Web UI](guides/web_ui.md) | Navigate and use the Depictio web interface |
+| [Dashboard Creation](guides/dashboard_creation.md) | Create and configure interactive dashboards |
+| [Using the Dashboard](guides/dashboard_usage.md) | Explore data through filters and selections |
 
-<!-- ## Administration
+<div class="grid cards" markdown>
 
-For system administrators, we provide guidance on managing Depictio:
+-   :material-monitor-dashboard:{ .lg .middle } **Web UI**
 
-- [Administration Guide](administration.md) - User management, system configuration, and maintenance -->
+    ---
+
+    Navigate the Depictio interface
+
+    [:octicons-arrow-right-24: Web UI Guide](guides/web_ui.md)
+
+-   :material-view-dashboard-edit:{ .lg .middle } **Dashboard Creation**
+
+    ---
+
+    Build and configure interactive dashboards
+
+    [:octicons-arrow-right-24: Dashboard Creation](guides/dashboard_creation.md)
+
+-   :material-gesture-tap:{ .lg .middle } **Using the Dashboard**
+
+    ---
+
+    Explore your data with filters and selections
+
+    [:octicons-arrow-right-24: Dashboard Usage](guides/dashboard_usage.md)
+
+</div>
+
+---
+
+## :material-folder-multiple: Projects
+
+Everything you need to configure and manage Depictio projects.
+
+| Page | Description |
+|------|-------------|
+| [Guide](projects/guide.md) | Project types (Basic, Advanced, Template) and lifecycle |
+| [YAML Examples](projects/yaml-examples.md) | Configuration patterns with annotated examples |
+| [Full Reference](projects/reference.md) | Complete YAML field reference |
+
+<div class="grid cards" markdown>
+
+-   :material-book-outline:{ .lg .middle } **Projects Guide**
+
+    ---
+
+    Understand project types and the full project lifecycle
+
+    [:octicons-arrow-right-24: Projects Guide](projects/guide.md)
+
+-   :material-code-braces:{ .lg .middle } **YAML Examples**
+
+    ---
+
+    Annotated configuration patterns for every use case
+
+    [:octicons-arrow-right-24: YAML Examples](projects/yaml-examples.md)
+
+-   :material-file-document-outline:{ .lg .middle } **Full Reference**
+
+    ---
+
+    Complete reference for every YAML configuration field
+
+    [:octicons-arrow-right-24: Reference](projects/reference.md)
+
+</div>
+
+---
+
+## :material-console: CLI
+
+Command-line tools for data ingestion, recipes, and templates.
+
+| Page | Description |
+|------|-------------|
+| [Usage](../depictio-cli/usage.md) | All CLI commands with options and examples |
+| [Minimal YAML Config](../depictio-cli/minimal_config.md) | Minimal project YAML to get started |
+| [Recipes](projects/recipes.md) | Data transformation recipes for bioinformatics pipelines |
+| [Templates](projects/templates.md) | One-command project setup for nf-core pipelines |
+
+<div class="grid cards" markdown>
+
+-   :material-terminal:{ .lg .middle } **CLI Usage**
+
+    ---
+
+    Full reference for every `depictio` command
+
+    [:octicons-arrow-right-24: CLI Reference](../depictio-cli/usage.md)
+
+-   :material-chef-hat:{ .lg .middle } **Recipes**
+
+    ---
+
+    Transform raw pipeline output into dashboard-ready tables
+
+    [:octicons-arrow-right-24: Recipes Guide](projects/recipes.md)
+
+-   :material-layers:{ .lg .middle } **Templates**
+
+    ---
+
+    Set up a complete nf-core project with a single command
+
+    [:octicons-arrow-right-24: Templates Guide](projects/templates.md)
+
+</div>
+
+---
+
+## :material-shield-account: Administration
+
+Operational tasks for managing Depictio deployments.
+
+| Page | Description |
+|------|-------------|
+| [Project Migration](administration/migrate.md) | Move projects between Depictio instances |
+
+<div class="grid cards" markdown>
+
+-   :material-transfer:{ .lg .middle } **Project Migration**
+
+    ---
+
+    Non-destructively migrate projects between Depictio instances
+
+    [:octicons-arrow-right-24: Migration Guide](administration/migrate.md)
+
+</div>
+
+---
+
+## :material-toggle-switch: Special Modes
+
+Alternative authentication and access configurations.
+
+| Page | Description |
+|------|-------------|
+| [Authentication Modes](guides/authentication-modes.md) | Configure authentication for your deployment |
+| [Unauthenticated Mode](guides/unauthenticated_mode.md) | Quick access without login (legacy) |

--- a/docs/usage/administration/backup.md
+++ b/docs/usage/administration/backup.md
@@ -3,7 +3,7 @@ title: Backup & Restore
 description: Back up and restore Depictio MongoDB data using the CLI.
 ---
 
-# :material-database-export: Backup & Restore
+# :material-database-export:{ style="color: #009688" } Backup & Restore
 
 The `depictio-cli backup` commands let administrators snapshot the MongoDB database and restore it from a previous backup. All backup operations require admin credentials.
 

--- a/docs/usage/administration/backup.md
+++ b/docs/usage/administration/backup.md
@@ -1,0 +1,101 @@
+---
+title: Backup & Restore
+description: Back up and restore Depictio MongoDB data using the CLI.
+---
+
+# :material-database-export: Backup & Restore
+
+The `depictio-cli backup` commands let administrators snapshot the MongoDB database and restore it from a previous backup. All backup operations require admin credentials.
+
+!!! warning "Admin only"
+    All `backup` sub-commands require the authenticated user to be an administrator.
+
+---
+
+## Commands
+
+### `backup create`
+
+Create a server-side snapshot of the MongoDB database. Short-lived tokens and temporary users are excluded automatically.
+
+```bash
+depictio-cli backup create
+
+# Also back up S3 Delta Lake files
+depictio-cli backup create --include-s3-data --s3-backup-prefix my-backup
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--include-s3-data` | `false` | Also back up S3 Delta Lake files |
+| `--s3-backup-prefix` | `"backup"` | Prefix for the S3 backup folder |
+| `--dry-run` | `false` | Validate the backup process without writing anything |
+
+On success, prints a backup ID (format `YYYYMMDD_HHMMSS`) and document counts per collection.
+
+---
+
+### `backup list`
+
+List all available backups stored on the server.
+
+```bash
+depictio-cli backup list
+```
+
+---
+
+### `backup validate`
+
+Check that a backup file is well-formed and passes Pydantic model validation before attempting a restore.
+
+```bash
+depictio-cli backup validate 20260315_143000
+```
+
+---
+
+### `backup restore`
+
+!!! danger "Destructive operation"
+    Restore **replaces existing data** in the selected collections. Use `--dry-run` first to preview what would change.
+
+Restore all or selected collections from a backup snapshot.
+
+```bash
+# Preview first
+depictio-cli backup restore 20260315_143000 --dry-run
+
+# Restore everything (prompts for confirmation)
+depictio-cli backup restore 20260315_143000
+
+# Restore specific collections only
+depictio-cli backup restore 20260315_143000 --collections projects,dashboards
+
+# Skip confirmation prompt (automation / CI)
+depictio-cli backup restore 20260315_143000 --force
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `false` | Simulate restore without writing any changes |
+| `--collections` | all | Comma-separated list of collections to restore |
+| `--force` | `false` | Skip the confirmation prompt |
+
+---
+
+## Typical workflow
+
+```bash
+# 1. Create a backup before a major operation
+depictio-cli backup create
+
+# 2. Validate the backup
+depictio-cli backup validate 20260315_143000
+
+# 3. Dry-run a restore to see what would change
+depictio-cli backup restore 20260315_143000 --dry-run
+
+# 4. Restore if needed
+depictio-cli backup restore 20260315_143000
+```

--- a/docs/usage/administration/index.md
+++ b/docs/usage/administration/index.md
@@ -1,0 +1,14 @@
+---
+title: Administration
+icon: material/shield-account
+description: Operational tasks for managing Depictio deployments.
+---
+
+# :material-shield-account: Administration
+
+Operational tasks for managing Depictio deployments.
+
+| Page | Description |
+|------|-------------|
+| [Project Migration](migrate.md) | Move projects between Depictio instances non-destructively |
+| [Backup & Restore](backup.md) | Snapshot and restore the MongoDB database |

--- a/docs/usage/administration/migrate.md
+++ b/docs/usage/administration/migrate.md
@@ -1,0 +1,131 @@
+# :material-database-arrow-right:{ style="color: #009688" } Project Migration
+
+Depictio supports **non-destructive project migration** between instances — move a project (MongoDB metadata + S3 data files + dashboards) from one Depictio deployment to another without touching any other project on the target.
+
+## Overview
+
+Migration works as a scoped upsert: every document is written via `ReplaceOne(..., upsert=True)`, so:
+
+- Re-running migration is idempotent — no duplicates are created.
+- Only the migrated project's documents are affected — all other projects on the target remain untouched.
+- Owner IDs that do not exist on the target are remapped to the importing admin user.
+
+## How It Works
+
+The CLI and UI paths differ in how S3 data is transferred:
+
+```
+CLI path (S3 copied directly)
+──────────────────────────────────────────────────────────────────
+Source instance                        Target instance
+depictio-cli                           API: /migrate/import-project
+    │                                       │
+    ├─ POST /migrate/export-project         ├─ Upsert: projects
+    │     → ZIP (no S3 data inside)         │     (workflows + data_collections
+    │       ├─ bundle.json                  │      are embedded in project doc)
+    │       ├─ migrate_metadata.json        ├─ Upsert: files / deltatables / runs
+    │       └─ s3_metadata.json             └─ Upsert: dashboards
+    │
+    └─ S3 copy: source MinIO → target MinIO (direct, not via ZIP)
+
+
+UI path (S3 bundled inside ZIP)
+──────────────────────────────────────────────────────────────────
+Browser                                Target instance
+    │                                       │
+    ├─ POST /migrate/export-project         ├─ POST /migrate/import-project-zip
+    │     → ZIP (S3 data included)          │     extracts bundle.json
+    │       ├─ bundle.json                  │     restores s3_data/* → MinIO
+    │       ├─ migrate_metadata.json        └─ Upsert: same order as CLI path
+    │       ├─ s3_metadata.json
+    │       └─ s3_data/<original S3 paths>
+    │
+    └─ ZIP downloaded to browser, re-uploaded to target UI
+```
+
+### ZIP Archive Contents
+
+| File / Folder | Always present | Description |
+|---|:---:|---|
+| `bundle.json` | ✅ | MongoDB documents — project (with embedded workflows + data_collections), files, deltatables, runs, dashboards |
+| `migrate_metadata.json` | ✅ | Export timestamp, project name, mode, Depictio version, document counts |
+| `s3_metadata.json` | ✅ | S3 paths discovered, file/byte counts, errors |
+| `s3_data/` | UI only (mode `all`/`files`) | S3 objects bundled at their original paths for cross-instance UI import |
+
+> **Note:** Workflows and data collections are not stored in separate MongoDB collections — they are embedded inside the project document and are exported/imported as part of `projects` in `bundle.json`.
+
+## Migration Modes
+
+| Mode        | MongoDB docs | S3 files | Typical use case                              |
+| ----------- | :----------: | :------: | --------------------------------------------- |
+| `all`       | ✅           | ✅       | First-time full migration                     |
+| `metadata`  | ✅           | ❌       | Both instances share the same S3 bucket       |
+| `dashboard` | dashboards only | ❌    | Project exists on remote, updating layouts    |
+| `files`     | ❌           | ✅       | MongoDB already migrated, syncing data files  |
+
+## CLI Usage
+
+See [CLI Reference — migrate](../../depictio-cli/usage.md#migrate-commands) for the full option reference.
+
+```bash
+# Recommended: dry-run first
+depictio-cli migrate \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml \
+  --dry-run
+
+# Full migration
+depictio-cli migrate \
+  --project "My Project" \
+  --CLI-config-path ~/.depictio/CLI_local.yaml \
+  --target-config ~/.depictio/CLI_remote.yaml
+```
+
+Each config file points to a different Depictio instance and carries its own API URL, token, and S3 credentials.
+
+## Web UI
+
+Migration is also available directly from the Projects page — no CLI required.
+
+### Export a Project
+
+1. Open **Projects** (`/projects`).
+2. Expand the project you want to export.
+3. Open the **Project Management** accordion section.
+4. Click **Export Project** (violet button).
+5. A `.zip` file downloads automatically — this is the same bundle the CLI produces.
+
+### Import a Project
+
+1. Click **Create New Project**.
+2. Switch to the **Import** tab.
+3. Drag-and-drop (or browse for) the `.zip` bundle.
+4. A preview shows the project name, export mode, and document counts.
+5. Click **Import Project** — the project is created and owned by your account.
+
+<!-- prettier-ignore -->
+!!! note "Owner remapping"
+    When importing via the UI, all project and dashboard owners in the bundle are automatically remapped to the importing user. This differs from the CLI, which only remaps owners that do not already exist on the target instance.
+
+## S3 Data Scope
+
+When `mode=all` or `mode=files`, the migrate feature copies S3 objects for all supported data collection types:
+
+| Data Collection Type | S3 location source                                        |
+| -------------------- | --------------------------------------------------------- |
+| Delta Lake / Table   | `deltatables.delta_table_location`                        |
+| GeoJSON              | `data_collections.config.dc_specific_properties.s3_location` |
+| Image                | `data_collections.config.dc_specific_properties.s3_base_folder` |
+| MultiQC              | `multiqc_reports.s3_location`                             |
+| JBrowse2             | S3 URIs in `jbrowse_collection.tracks[].uri`              |
+
+S3 objects are streamed directly from source to target (no full buffering in RAM).
+
+## Permissions
+
+Both the CLI and UI require **administrator** privileges:
+
+- **CLI**: both source and target configs must authenticate as admins.
+- **UI export**: the user must be admin (or project owner).
+- **UI import**: the user must be admin; all document owners are remapped to the importing user.

--- a/docs/usage/guides/authentication-modes.md
+++ b/docs/usage/guides/authentication-modes.md
@@ -1,10 +1,9 @@
 ---
 title: "Authentication Modes"
-icon: material/shield-account
 description: "Depictio supports four authentication modes to fit different deployment scenarios."
 ---
 
-# Authentication Modes
+# :material-shield-account:{ style="color: #009688" } Authentication Modes
 
 Depictio supports four authentication modes, each designed for a different deployment scenario. Only one mode is active at a time.
 

--- a/docs/usage/guides/index.md
+++ b/docs/usage/guides/index.md
@@ -1,0 +1,16 @@
+---
+title: Guides
+icon: material/book-open-variant
+description: Hands-on guides for using Depictio's web interface.
+---
+
+# :material-book-open-variant: Guides
+
+Hands-on guides for common tasks in the Depictio web interface.
+
+| Page | Description |
+|------|-------------|
+| [Web UI](web_ui.md) | Navigate and use the Depictio web interface |
+| [Dashboard Creation](dashboard_creation.md) | Create and configure interactive dashboards |
+| [Using the Dashboard](dashboard_usage.md) | Explore data through filters and selections |
+| [Authentication Modes](authentication-modes.md) | Configure authentication for your deployment |

--- a/docs/usage/projects/index.md
+++ b/docs/usage/projects/index.md
@@ -1,0 +1,17 @@
+---
+title: Projects
+icon: material/folder-multiple
+description: Configure and manage Depictio projects.
+---
+
+# :material-folder-multiple: Projects
+
+Everything you need to configure and manage Depictio projects.
+
+| Page | Description |
+|------|-------------|
+| [Guide](guide.md) | Project types (Basic, Advanced, Template) and lifecycle |
+| [YAML Examples](yaml-examples.md) | Configuration patterns with annotated examples |
+| [Full Reference](reference.md) | Complete YAML field reference |
+| [Recipes](recipes.md) | Data transformation recipes for bioinformatics pipelines |
+| [Templates](templates.md) | One-command project setup for nf-core pipelines |

--- a/docs/usage/special-modes/index.md
+++ b/docs/usage/special-modes/index.md
@@ -1,0 +1,14 @@
+---
+title: Special Modes
+icon: material/tune-variant
+description: Authentication and deployment modes for Depictio.
+---
+
+# :material-tune-variant: Special Modes
+
+Configuration modes that change how Depictio handles authentication and user access.
+
+| Page | Description |
+|------|-------------|
+| [Authentication Modes](../guides/authentication-modes.md) | Configure OAuth, local auth, and admin-only access |
+| [Unauthenticated Mode](../guides/unauthenticated_mode.md) | Run Depictio without requiring user login (legacy) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,21 +192,24 @@ nav:
       - Overview: usage/README.md
       - Getting Started: usage/get_started.md
       - Guides:
+          - usage/guides/index.md
           - WebUI: usage/guides/web_ui.md
           - Dashboard creation: usage/guides/dashboard_creation.md
           - Using the dashboard: usage/guides/dashboard_usage.md
       - Projects:
+          - usage/projects/index.md
           - Guide: usage/projects/guide.md
           - YAML project configuration breakdown: usage/projects/yaml-examples.md
           - Full Reference Configuration: usage/projects/reference.md
       - CLI:
+          - depictio-cli/index.md
           - Usage: depictio-cli/usage.md
           - Minimal YAML config: depictio-cli/minimal_config.md
       - Special Modes:
           - Authentication Modes: usage/guides/authentication-modes.md
           - Unauthenticated mode (legacy): usage/guides/unauthenticated_mode.md
       - Administration:
-          - Overview: usage/administration/index.md
+          - usage/administration/index.md
           - Backup & Restore: usage/administration/backup.md
           - Project Migration: usage/administration/migrate.md
   - Features:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,6 +217,8 @@ nav:
           - Cross-DC Filtering: features/cross-dc-filtering.md
           - Filter Expressions: features/filter-expressions.md
           - YAML Dashboard Sync: features/yaml-sync.md
+      - Administration:
+          - Project Migration: features/migrate.md
       - System Design:
           - Architecture: features/architecture.md
           - Data Model: features/data-model.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,8 +205,10 @@ nav:
       - Special Modes:
           - Authentication Modes: usage/guides/authentication-modes.md
           - Unauthenticated mode (legacy): usage/guides/unauthenticated_mode.md
-      # - Administration:
-      #     - Overview: usage/administration.md
+      - Administration:
+          - Overview: usage/administration/index.md
+          - Backup & Restore: usage/administration/backup.md
+          - Project Migration: usage/administration/migrate.md
   - Features:
       - Overview: features/README.md
       - Dashboard & Components:
@@ -217,8 +219,6 @@ nav:
           - Cross-DC Filtering: features/cross-dc-filtering.md
           - Filter Expressions: features/filter-expressions.md
           - YAML Dashboard Sync: features/yaml-sync.md
-      - Administration:
-          - Project Migration: features/migrate.md
       - System Design:
           - Architecture: features/architecture.md
           - Data Model: features/data-model.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -206,6 +206,7 @@ nav:
           - Usage: depictio-cli/usage.md
           - Minimal YAML config: depictio-cli/minimal_config.md
       - Special Modes:
+          - usage/special-modes/index.md
           - Authentication Modes: usage/guides/authentication-modes.md
           - Unauthenticated mode (legacy): usage/guides/unauthenticated_mode.md
       - Administration:


### PR DESCRIPTION
## Summary

- New **Administration** section under Usage with sidebar icons
- **Project Migration** page — full CLI + UI docs, correct ZIP structure (CLI vs UI paths), teal `material/database-arrow-right` icon
- **Backup & Restore** page — revised to use `depictio-cli backup` commands, teal `material/database-export` icon
- Sidebar icons added for Guides, Projects, CLI, Special Modes, and Administration sections
- Authentication Modes page — teal title icon, sidebar icon removed
- `depictio-cli/usage.md` — `migrate run` → `migrate` throughout

## Test plan

- [ ] Verify Administration section appears in sidebar under Usage
- [ ] Verify all section icons render correctly
- [ ] Verify migrate page ZIP structure diagrams are accurate
- [ ] Verify backup page uses `depictio-cli backup` in all code blocks