### PR TITLE
docs: backfill v0.12.0 changelog entry

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -8,6 +8,62 @@ hide:
 
 # Changelog
 
+## **[v0.12.0](https://github.com/depictio/depictio/releases/tag/v0.12.0)** (May 15, 2026)
+
+!!! warning "Minor Release — React viewer data-management UX"
+    First release where the React (Beta) viewer can **create and manage**
+    Data Collections end-to-end: MultiQC lifecycle, cross-DC links, and a
+    new Map-capable table DC with coordinates detection. The legacy Dash UI
+    is unchanged.
+
+### Docker Images
+
+```bash
+ghcr.io/depictio/depictio:0.12.0
+```
+
+### **✨ New Features**
+
+* **MultiQC DC management in React** — full create / append / replace / clear
+  lifecycle via new HTTP endpoints, with a unified *Manage Data Collection*
+  modal, folder uploads, live cache + Celery prewarm, disk-persistent
+  prerender store, and authorization on destructive endpoints.
+* **MultiQC uniformity validator** — dry-run check endpoint and *Check now*
+  button surface uniformity issues before ingest; runs automatically on the
+  create flow with a checklist UI.
+* **Cross-DC link CRUD in React** — create / edit / delete links from the
+  viewer with a polished modal; Cytoscape link graph handles enriched
+  aggregation specs and missing column nodes; links cascade-delete with their
+  DC.
+* **Map-capable table DC** — new `DCTableCoordinatesConfig` variant. The
+  Create DC modal has a **Coordinates** tab, inline DC previews, and inline
+  lat/lon detection; `/create_from_upload` accepts `latColumn`/`lonColumn`
+  hints with column validation.
+* **Dashboards & Projects revamp (React)** — new toolbar, table view, pins,
+  and filters across `/dashboards-beta` and `/projects-beta`; canonical
+  `selected_*` keys + SPA route polish.
+
+### **🚀 Improvements**
+
+* MultiQC: disk-persistent prerender store + Celery worker rebuild, longer
+  preview offload timeout, collapsed multi-line log, safer append, cache-key
+  correctness.
+* Helm: ConfigMap/Secret content checksum rolls dependent Pods on change.
+* CI/Docker: pin `pnpm@10` in `viewer-builder` and `dev-viewer` stages;
+  viewer-dev Vite port wired through the dev-port allocator.
+
+### **🐛 Bug Fixes**
+
+* Viewer: hide demo banner + tour in React routes; favicon path rewritten by
+  Vite `base`; side-by-side worktree dev stacks unblocked.
+* Cytoscape: handle `aggregation_columns_specs` as list of dicts; extract DC
+  columns from enriched specs; resolve edges referencing nonexistent column
+  nodes.
+* MultiQC: skip scan step on create, fix file naming, tighten suffix regex.
+* Screenshots: regenerate clean example dashboard previews.
+
+---
+
 ## **[v0.11.2](https://github.com/depictio/depictio/releases/tag/v0.11.2)** (May 7, 2026)
 
 !!! success "Stable Release"


### PR DESCRIPTION
## Summary
- Adds v0.12.0 entry to the top of `docs/changelog/README.md` (May 15, 2026).
- Covers React-viewer data-management UX: MultiQC DC management lifecycle + uniformity validator, cross-DC link CRUD, Map-capable table DC with coordinates detection, Dashboards/Projects page revamp.
- Improvements (MultiQC perf, Helm checksum rollout, pnpm@10 pinning) + bug fixes (viewer demo gating, Cytoscape, MultiQC create flow, screenshots).

Bot-generated bump PR (auto-opened against this repo on tag push) will follow with the version/openapi snapshot bump.

## Test plan
- [x] markdownlint passes
- [x] check-mkdocs-links passes
- [ ] Visual: entry renders above v0.11.2 with the warning callout