### PR TITLE
docs(release): v0.13.1 stable

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -8,12 +8,18 @@ hide:
 
 # Changelog
 
-## **v0.13.1** (unreleased)
+## **[v0.13.1](https://github.com/depictio/depictio/releases/tag/v0.13.1)** (May 21, 2026)
 
-!!! note "Patch — seed projects, MultiQC filter, /admin-beta polish"
+!!! success "Stable Release — seed projects, MultiQC filter, /admin-beta polish"
     Adds nf-core/viralrecon as a fifth seed project and fixes
     cross-DC filtering on MultiQC, the date range picker, and a few
     React viewer rough edges.
+
+### Docker Images
+
+```bash
+ghcr.io/depictio/depictio:0.13.1
+```
 
 ### **✨ New Features**
 


### PR DESCRIPTION
## Summary

- Mark **v0.13.1 as stable** (was `(unreleased)`):
  - Heading now dated `May 21, 2026` and linked to the GitHub release tag
  - Admonition class switched from `note` to `success` ("Stable Release — ...")
  - Added `Docker Images` block with `ghcr.io/depictio/depictio:0.13.1` — matches every prior stable release
- Includes the prior v0.13.1 prep already on this branch: env-reference cleanup, ampliseq + viralrecon template page refresh, and the initial changelog split commit.

## Release context

- depictio repo: `v0.13.1` tag landed earlier today (commit `73d83f085` on main, `stable` tag force-pushed).
- After merge, this PR's main-push will trigger `deploy-docs.yaml` → mike v0.13.1 deploy.

## Test plan

- [x] `mkdocs build` link-checker passes (pre-commit)
- [ ] CI green