### PR TITLE
docs(index): mark Text + Advanced viz as shipped on landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -146,21 +146,19 @@ hide:
         <h4>Map</h4>
         <p>Geospatial map visualization with markers</p>
       </div>
-      <div class="component-card component-card-upcoming">
-        <span class="component-badge">Coming soon</span>
-        <div class="component-icon" style="background: #6c757d;">
+      <div class="component-card">
+        <div class="component-icon" style="background: #e91e63;">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M5,4V7H10.5V19H13.5V7H19V4H5Z"/>
+            <path d="M10 19.11L12.11 17H7v-2h7v.12L16.12 13H7v-2h10v1.12l1.24-1.23c.48-.48 1.11-.75 1.8-.75c.33 0 .66.07.96.19V5a2 2 0 0 0-2-2H5c-1.11 0-2 .89-2 2v14a2 2 0 0 0 2 2h5zM7 7h10v2H7zm14.7 7.35l-1 1l-2.05-2.05l1-1a.55.55 0 0 1 .77 0l1.28 1.28c.21.21.21.56 0 .77M12 19.94l6.06-6.06l2.05 2.05L14.06 22H12z"/>
           </svg>
         </div>
         <h4>Text</h4>
-        <p>Markdown blocks for documentation, narratives, and annotations</p>
+        <p>Section headings and notes to document the dashboard</p>
       </div>
-      <div class="component-card component-card-upcoming">
-        <span class="component-badge">Coming soon</span>
+      <div class="component-card">
         <div class="component-icon" style="background: #d6336c;">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M16,11.78L20.24,4.45L21.97,5.45L16.74,14.5L10.23,10.75L5.46,19H22V21H2V3H4V17.54L9.5,8L16,11.78Z"/>
+            <path d="M2 2h2v18h18v2H2zm12 12.5L12 18H7.94l-2.02-3.5L7.94 11H12zm.08-8L12.06 10H8L6 6.5L8 3h4.06zm7.17 4L19.23 14h-4.04l-2.02-3.5L15.19 7h4.04z"/>
           </svg>
         </div>
         <h4>Advanced viz</h4>


### PR DESCRIPTION
## Summary

The Dashboard Components card grid on the landing page (`docs/index.md`) still showed **Text** and **Advanced viz** with `Coming soon` badges and gray/placeholder styling even though both shipped months ago (Text in v0.12.1, Advanced viz in v0.13.0). The Text card also had a misleading description.

## Changes

- **Text card**: dropped `component-card-upcoming` class + `Coming soon` badge; background `#6c757d` (grey placeholder) → `#e91e63` (Material pink, matches the React viewer's `componentTypes.ts` registry); icon path → `mdi:text-box-edit`; description "Markdown blocks for documentation, narratives, and annotations" → "Section headings and notes to document the dashboard" (accurate: the renderer supports H1-H6 + inline markdown for bold/italic/code, not arbitrary markdown blocks)
- **Advanced viz card**: dropped `component-card-upcoming` class + `Coming soon` badge; background `#d6336c` retained (already matched the React viewer); icon path → `mdi:chart-scatter-plot-hexbin` (was a generic trending-line glyph)

## Test plan

- [ ] `mkdocs serve` — Text + Advanced viz cards render in colour with the right icons and no "Coming soon" badge
- [ ] Visual diff against the React viewer's `/dashboards-beta` → Create Component picker — same icons + colours