### PR TITLE
docs(landing): point live-demo iframe at React beta + refresh hero video

### DIFF
--- a/docs/blog/posts/depictio-goes-live.md
+++ b/docs/blog/posts/depictio-goes-live.md
@@ -233,8 +233,8 @@ Access the live demo at [demo.depictio.embl.org](https://demo.depictio.embl.org)
         <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
       </svg>
     </button>
-    <iframe id="demo-iframe" src="https://demo.depictio.embl.org/" width="100%" height="1080" frameborder="0" allowfullscreen style="zoom: 0.56;">
-      <p>Your browser does not support iframes. <a href="https://demo.depictio.embl.org/">Click here to view the Depictio dashboard</a></p>
+    <iframe id="demo-iframe" src="https://api.demo.depictio.embl.org/dashboards-beta" width="100%" height="1080" frameborder="0" allowfullscreen style="zoom: 0.56;">
+      <p>Your browser does not support iframes. <a href="https://api.demo.depictio.embl.org/dashboards-beta">Click here to view the Depictio dashboard</a></p>
     </iframe>
   </div>
 </section>
@@ -739,7 +739,7 @@ function toggleFullscreen() {
 async function checkDemoAvailability() {
   const demoSection = document.querySelector('.live-demo-section');
   const iframe = document.getElementById('demo-iframe');
-  const demoUrl = 'https://demo.depictio.embl.org/';
+  const demoUrl = 'https://api.demo.depictio.embl.org/dashboards-beta';
 
   if (!demoSection || !iframe) return;
 
@@ -776,7 +776,7 @@ async function checkDemoAvailability() {
           </svg>
         </div>
         <h3>Live Demo Temporarily Unavailable</h3>
-        <p>The interactive demo is currently not accessible. Please try again later or <a href="https://demo.depictio.embl.org/" target="_blank" rel="noopener">visit the demo site directly</a>.</p>
+        <p>The interactive demo is currently not accessible. Please try again later or <a href="https://api.demo.depictio.embl.org/dashboards-beta" target="_blank" rel="noopener">visit the demo site directly</a>.</p>
         <div class="demo-alternative-actions">
           <a href="https://codespaces.new/depictio/depictio" class="md-button" target="_blank" rel="noopener">Open in Codespaces</a>
           <a href="../../usage/get_started/" class="md-button">View Documentation</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ hide:
 
 <div style="padding: 64.29% 0 0 0; position: relative">
   <iframe
-    src="https://player.vimeo.com/video/1109036952?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1&amp;loop=1"
+    src="https://player.vimeo.com/video/1194664914?h=4155d79379&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1&amp;loop=1"
     frameborder="0"
     allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share"
     referrerpolicy="strict-origin-when-cross-origin"
@@ -242,8 +242,8 @@ hide:
         <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
       </svg>
     </button>
-    <iframe id="demo-iframe" src="https://demo.depictio.embl.org/" width="100%" height="1080" frameborder="0" allowfullscreen style="zoom: 0.56;">
-      <p>Your browser does not support iframes. <a href="https://demo.depictio.embl.org/">Click here to view the Depictio dashboard</a></p>
+    <iframe id="demo-iframe" src="https://api.demo.depictio.embl.org/dashboards-beta" width="100%" height="1080" frameborder="0" allowfullscreen style="zoom: 0.56;">
+      <p>Your browser does not support iframes. <a href="https://api.demo.depictio.embl.org/dashboards-beta">Click here to view the Depictio dashboard</a></p>
     </iframe>
   </div>
 </section>
@@ -2107,7 +2107,7 @@ function toggleFullscreen() {
 async function checkDemoAvailability() {
   const demoSection = document.querySelector('.live-demo-section');
   const iframe = document.getElementById('demo-iframe');
-  const demoUrl = 'https://demo.depictio.embl.org/';
+  const demoUrl = 'https://api.demo.depictio.embl.org/dashboards-beta';
 
   if (!demoSection || !iframe) return;
 
@@ -2144,7 +2144,7 @@ async function checkDemoAvailability() {
           </svg>
         </div>
         <h3>Live Demo Temporarily Unavailable</h3>
-        <p>The interactive demo is currently not accessible. Please try again later or <a href="https://demo.depictio.embl.org/" target="_blank" rel="noopener">visit the demo site directly</a>.</p>
+        <p>The interactive demo is currently not accessible. Please try again later or <a href="https://api.demo.depictio.embl.org/dashboards-beta" target="_blank" rel="noopener">visit the demo site directly</a>.</p>
         <div class="demo-alternative-actions">
           <a href="https://codespaces.new/depictio/depictio" class="md-button" target="_blank" rel="noopener">Open in Codespaces</a>
           <a href="usage/get_started/" class="md-button">View Documentation</a>


### PR DESCRIPTION
## Summary
- Swap the embedded **live-demo iframe** on the landing page (`docs/index.md`) and `depictio-goes-live` blog post from `https://demo.depictio.embl.org/` to `https://api.demo.depictio.embl.org/dashboards-beta` so the embedded experience drops visitors directly into the **React Beta viewer** (the canonical UI from v0.14.0). The iframe fallback `<a>`, the JS `demoUrl` reachability probe, and the "visit the demo site directly" link in the unavailable-fallback message all follow.
- "Live Demo" hero buttons + footer link still point at `https://demo.depictio.embl.org/` (signup / login entry) — intentionally untouched.
- Refresh the landing-page hero **Vimeo** embed to `https://player.vimeo.com/video/1194664914?h=4155d79379` (kept all existing query params + proportions).

## Test plan
- [ ] `mkdocs serve` locally — confirm landing-page hero video plays the new clip
- [ ] Confirm the embedded live demo on the landing page loads the React Beta viewer
- [ ] Same check inside the `depictio-goes-live` blog post