### PR TITLE
docs(api): merge openapi.json updates v0.13.9→v0.13.12

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2,9 +2,9 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Depictio API",
-    "version": "0.13.8",
-    "x-generated-at": "2026-05-28T14:57:34Z",
-    "x-depictio-version": "v0.13.8"
+    "version": "0.13.12",
+    "x-generated-at": "2026-05-29T09:40:33Z",
+    "x-depictio-version": "v0.13.12"
   },
   "paths": {
     "/depictio/api/v1/projects/get/all": {
@@ -197,7 +197,7 @@
           "Projects"
         ],
         "summary": "Create Project",
-        "description": "Create a new project.\n\nTolerates missing tokens so single-user / public mode can create projects\nwithout a persisted token — the inline owner / ``is_admin`` gate below\nstill rejects callers who aren't listed as owners and aren't admins.\n\nPublic/demo mode hard-blocks creation regardless of token: visitors are\nauto-minted as authenticated temp users, so the standard owner/admin gate\nwouldn't stop them from POSTing here directly. The frontend disables the\n\"Create Project\" button in public mode (see Dash\n`app_layout.return_create_project_button` and React `ProjectsApp.tsx`),\nand this check is the matching server-side enforcement.",
+        "description": "Create a new project.\n\nTolerates missing tokens so single-user / public mode can create projects\nwithout a persisted token — the inline owner / ``is_admin`` gate below\nstill rejects callers who aren't listed as owners and aren't admins.\n\nPublic/demo mode blocks creation for non-admin callers (anonymous + temp\nusers) regardless of token: visitors are auto-minted as authenticated temp\nusers, so the standard owner/admin gate wouldn't stop them from POSTing\nhere directly. Admins bypass this gate so they can still administer a\npublic/demo deployment. The frontend mirrors this (see Dash\n`app_layout.return_create_project_button` and React `ProjectsApp.tsx`).",
         "operationId": "create_project_depictio_api_v1_projects_create_post",
         "requestBody": {
           "content": {
@@ -5012,6 +5012,16 @@
               "type": "string",
               "format": "objectid",
               "title": "Dashboard Id"
+            }
+          },
+          {
+            "name": "force_screenshot",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Force Screenshot"
             }
           }
         ],
@@ -10332,7 +10342,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -10590,7 +10600,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -10652,7 +10662,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -10714,7 +10724,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -10839,7 +10849,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -10975,7 +10985,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -12134,7 +12144,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -12341,7 +12351,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -12490,7 +12500,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -13088,7 +13098,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -13293,7 +13303,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -13524,7 +13534,7 @@
             "format": "objectid",
             "title": "Sub",
             "description": "Subject of the token, typically the user ID",
-            "default": "6a1857da3b7c355b10724a61"
+            "default": "6a195f0b9ba68289685eadc3"
           }
         },
         "type": "object",
@@ -13642,7 +13652,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -13760,7 +13770,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -13841,7 +13851,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -13926,7 +13936,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -14011,7 +14021,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -14176,7 +14186,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -14317,7 +14327,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -14491,7 +14501,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -14559,7 +14569,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -14656,7 +14666,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [
@@ -14773,7 +14783,7 @@
             "type": "string",
             "format": "objectid",
             "title": "Id",
-            "default": "6a1857da3b7c355b10724a60"
+            "default": "6a195f0b9ba68289685eadc2"
           },
           "description": {
             "anyOf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ dependencies = [
     "mkdocs-kroki-plugin",
     "mkdocs-graphviz"
 ]
-version = "0.13.8"
+version = "0.13.12"
 name = "depictio-docs"


### PR DESCRIPTION
Squashes bot PRs #105–#108 (all touched the same openapi.json sequentially). Takes the final state from the v0.13.12 bot branch and applies it on top of main. Closes #105, #106, #107, #108.