### PR TITLE
docs: add live component catalog (Depictio Modules) page

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,6 +15,10 @@ on:
         description: 'Alias (latest, beta, or none)'
         required: false
         default: 'beta'
+      depictio_ref:
+        description: 'depictio/depictio ref to build the component catalog from'
+        required: false
+        default: 'main'
 
 jobs:
   deploy-mike:
@@ -57,6 +61,43 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
+
+      # The component catalog gallery is generated on the fly from the depictio
+      # source repo and is NOT committed to this repo (see .gitignore). mkdocs
+      # copies docs/assets/ into the build regardless of gitignore, so the freshly
+      # generated HTML ships with this mike version.
+      - name: Checkout depictio source (catalog gallery)
+        uses: actions/checkout@v4
+        with:
+          repository: depictio/depictio
+          ref: ${{ github.event.inputs.depictio_ref || 'main' }}
+          path: depictio-src
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Build catalog gallery bundle
+        working-directory: depictio-src
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter ./depictio/viewer run build:catalog-preview
+
+      # Run from depictio-src so uv resolves its pyproject.toml (installs the
+      # depictio package + deps into an isolated env, separate from the docs env).
+      - name: Generate catalog gallery HTML (light + dark)
+        working-directory: depictio-src
+        run: |
+          uv run python -m depictio.cli catalog gallery \
+            --theme light --no-open --out "$GITHUB_WORKSPACE/docs/assets/component-catalog-light.html"
+          uv run python -m depictio.cli catalog gallery \
+            --theme dark --no-open --out "$GITHUB_WORKSPACE/docs/assets/component-catalog-dark.html"
 
       - name: Deploy with mike
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ __pycache__/
 site/
 docs/site/
 
+# Generated on the fly in CI (catalog gallery, see deploy-docs.yaml) — never committed
+docs/assets/component-catalog-light.html
+docs/assets/component-catalog-dark.html
+
 # Editor/IDE
 .vscode/
 .idea/

--- a/docs/features/components.md
+++ b/docs/features/components.md
@@ -8,6 +8,11 @@ description: "Complete guide to Depictio's dashboard component types and their c
 
 Depictio provides a variety of component types for building interactive dashboards. This guide covers each component type, when to use it, and how to configure it.
 
+!!! tip "Browse the live catalog"
+    To see which bioinformatics tool outputs map to these components, explore the
+    interactive [:material-view-module: Depictio Modules](../modules/index.md) gallery —
+    a live, offline catalog of tool-to-component integrations.
+
 ## :material-format-list-bulleted: Component Overview
 
 <div class="grid cards" markdown>

--- a/docs/javascripts/catalog-fullscreen.js
+++ b/docs/javascripts/catalog-fullscreen.js
@@ -1,0 +1,61 @@
+// Page-fill "fullscreen" toggle for the component-catalog gallery embed.
+// Toggles a fixed-position overlay class instead of the native Fullscreen API:
+// the gallery fills the browser viewport (tab), not the whole screen.
+
+// Icon paths (Material Design Icons): expand <-> collapse.
+const CATALOG_FS_EXPAND = 'M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z';
+const CATALOG_FS_COLLAPSE = 'M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z';
+
+const CATALOG_FS_CLASS = 'catalog-embed--fs';
+const CATALOG_FS_LOCK = 'catalog-fs-lock';
+
+function activeCatalogEmbed() {
+  return document.querySelector('.catalog-embed.' + CATALOG_FS_CLASS);
+}
+
+function setCatalogFullscreen(container, on) {
+  container.classList.toggle(CATALOG_FS_CLASS, on);
+  // Freeze the page behind the overlay while it is open.
+  document.body.classList.toggle(CATALOG_FS_LOCK, on);
+  const button = container.querySelector('.catalog-fs-btn');
+  if (!button) return;
+  const icon = button.querySelector('svg path');
+  if (icon) icon.setAttribute('d', on ? CATALOG_FS_COLLAPSE : CATALOG_FS_EXPAND);
+  button.setAttribute('title', on ? 'Exit fullscreen' : 'Toggle fullscreen');
+  button.setAttribute('aria-label', on ? 'Exit fullscreen' : 'Toggle fullscreen');
+}
+
+function toggleCatalogFullscreen(el) {
+  const container = el.closest('.catalog-embed');
+  if (!container) return;
+  const active = activeCatalogEmbed();
+  if (active && active !== container) setCatalogFullscreen(active, false);
+  setCatalogFullscreen(container, !container.classList.contains(CATALOG_FS_CLASS));
+}
+
+// Expose for the inline onclick handlers (kept global like the live demo).
+window.toggleCatalogFullscreen = toggleCatalogFullscreen;
+
+// ESC exits the overlay (the native API gave this for free; replicate it).
+function wireCatalogFs() {
+  if (window.__catalogFsWired) return;
+  window.__catalogFsWired = true;
+  document.addEventListener('keydown', function (e) {
+    if (e.key !== 'Escape') return;
+    const active = activeCatalogEmbed();
+    if (active) setCatalogFullscreen(active, false);
+  });
+}
+
+function resetCatalogFs() {
+  // Material instant navigation swaps the page content: drop a stale scroll
+  // lock if the user navigated away while the overlay was open.
+  document.body.classList.remove(CATALOG_FS_LOCK);
+  wireCatalogFs();
+}
+
+if (typeof document$ !== 'undefined' && document$.subscribe) {
+  document$.subscribe(resetCatalogFs);
+} else {
+  document.addEventListener('DOMContentLoaded', resetCatalogFs);
+}

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -1,0 +1,97 @@
+---
+title: "Depictio Modules"
+icon: material/view-module
+description: "Browse the live catalog of Depictio modules — reusable integrations that turn bioinformatics tool outputs into dashboard components."
+hide:
+  - navigation
+  - toc
+---
+
+# :material-view-module: Depictio Modules
+
+**A module maps a workflow's output files to predefined visualizations.**
+Point Depictio at a pipeline run — every output a module recognises becomes a
+dashboard component, with no manual wiring.
+
+<div class="module-flow" markdown>
+
+<div class="module-flow__step module-flow__step--file" markdown>
+:material-file-document-outline:{ .lg } **Workflow output**
+
+A file your pipeline produced — stats tables, metrics, reports.
+</div>
+
+<div class="module-flow__step module-flow__step--module" markdown>
+:material-view-module:{ .lg } **Module**
+
+Recognises the tool's file and prepares its columns.
+</div>
+
+<div class="module-flow__step module-flow__step--component" markdown>
+:material-view-dashboard-variant:{ .lg } **Visualization**
+
+A predefined component — figure, table, card, or advanced viz.
+</div>
+
+</div>
+
+Browse the catalog below: filter by component type or kind, and inspect each
+output's exact column bindings.
+
+<div class="catalog-embed" markdown>
+  <div class="catalog-demo-header">
+    <span class="catalog-demo-title">Depictio Modules</span>
+    <button class="catalog-fs-close" type="button" onclick="toggleCatalogFullscreen(this)" title="Exit fullscreen" aria-label="Exit fullscreen">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
+    </button>
+  </div>
+  <button class="catalog-fs-btn" type="button" onclick="toggleCatalogFullscreen(this)" title="Toggle fullscreen" aria-label="Toggle fullscreen">
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/></svg>
+  </button>
+  <div class="catalog-iframe-light">
+    <iframe src="../assets/component-catalog-light.html" title="Depictio modules catalog (light)" width="100%" height="1100px" frameborder="0" loading="lazy"></iframe>
+  </div>
+  <div class="catalog-iframe-dark">
+    <iframe src="../assets/component-catalog-dark.html" title="Depictio modules catalog (dark)" width="100%" height="1100px" frameborder="0" loading="lazy"></iframe>
+  </div>
+</div>
+
+## :material-sitemap: How a module works
+
+Every module follows the same path — from a raw file on disk to a live dashboard
+component:
+
+<div class="module-flow" markdown>
+
+<div class="module-flow__step module-flow__step--detect" markdown>
+:material-file-search:{ .lg } **Detect**
+
+Recognise which file in a run is this tool's output, by filename or path pattern.
+</div>
+
+<div class="module-flow__step module-flow__step--reshape" markdown>
+:material-cog-transfer:{ .lg } **Reshape** <span class="module-flow__opt">optional</span>
+
+Transform the raw file into tidy, bindable columns. Already-tidy outputs skip this.
+</div>
+
+<div class="module-flow__step module-flow__step--render" markdown>
+:material-view-dashboard-variant:{ .lg } **Render**
+
+Bind those columns to a dashboard component — chart, table, card, or advanced viz.
+</div>
+
+</div>
+
+!!! info "Validated bindings"
+    Column schemas live in exactly one place per output, and continuous integration
+    validates every render binding against the real reshaped columns — so a module
+    that ships green is wired correctly, with no manual review.
+
+For the configuration reference of each component type, see the
+[:material-puzzle: Dashboard Components](../features/components.md) guide.
+
+!!! tip "Add a module"
+    Extending the catalog is a single-folder contribution: a small module definition
+    plus one description per output and a fixture file. See the catalog README in the
+    depictio repository for the full contract.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -911,3 +911,193 @@ svg:hover path#shape-7 {
         gap: 1rem !important;
     }
 }
+
+/* ==========================================================================
+   Component Catalog page
+   ========================================================================== */
+
+/* Theme-aware live gallery iframes — mirrors the .logo-light/.logo-dark trick
+   above (the image #only-light/#only-dark hash does not apply to iframes). */
+[data-md-color-scheme="default"] .catalog-iframe-light { display: block; }
+[data-md-color-scheme="default"] .catalog-iframe-dark { display: none; }
+[data-md-color-scheme="slate"] .catalog-iframe-light { display: none; }
+[data-md-color-scheme="slate"] .catalog-iframe-dark { display: block; }
+
+/* Full-height gallery: fill the viewport (the page hides nav + toc, so it can
+   use the whole content column). The height="" attribute is just a fallback. */
+.catalog-embed {
+    position: relative;
+}
+
+.catalog-embed iframe {
+    display: block;
+    width: 100%;
+    height: 100vh;
+    min-height: 1100px;
+    border-radius: 4px;
+    border: 1px solid var(--md-default-fg-color--lightest);
+}
+
+/* Fullscreen toggle (reused from the live-demo pattern). */
+.catalog-fs-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    border: none;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.catalog-fs-btn:hover {
+    background: rgba(0, 0, 0, 0.9);
+}
+
+/* Header bar (with close button) shown only in fullscreen. */
+.catalog-demo-header {
+    display: none;
+}
+
+/* Page-fill overlay: fixed over the docs page, not native OS fullscreen. */
+.catalog-embed--fs {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    margin: 0;
+    padding: 0;
+    background: var(--md-default-bg-color);
+}
+
+/* Freeze the page scroll behind the overlay (set by catalog-fullscreen.js). */
+body.catalog-fs-lock {
+    overflow: hidden;
+}
+
+/* The footer fix pins .md-main to z-index:1, which traps the overlay in a
+   stacking context below the sticky Material header (z-index:4). While the
+   overlay is open, lift the whole content stacking context above it. */
+body.catalog-fs-lock .md-main {
+    z-index: 1001;
+}
+
+.catalog-embed--fs .catalog-demo-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 48px;
+    padding: 0 1rem;
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.catalog-demo-title {
+    font-weight: 600;
+}
+
+.catalog-fs-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--md-default-fg-color);
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.catalog-fs-close:hover {
+    background: var(--md-default-fg-color--lightest);
+}
+
+.catalog-embed--fs .catalog-fs-btn {
+    display: none;
+}
+
+.catalog-embed--fs .catalog-iframe-light,
+.catalog-embed--fs .catalog-iframe-dark {
+    height: calc(100vh - 48px);
+}
+
+.catalog-embed--fs iframe {
+    width: 100vw;
+    height: calc(100vh - 48px);
+    min-height: 0;
+    border: none;
+    border-radius: 0;
+}
+
+/* Module flow: a flat horizontal stepper (Detect -> Reshape -> Render). */
+.module-flow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.6rem;
+    margin: 1rem 0 1.5rem;
+}
+
+.module-flow__step {
+    position: relative;
+    flex: 1 1 200px;
+    padding: 0.9rem 1.1rem;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-top: 3px solid var(--md-default-fg-color--light);
+    border-radius: 6px;
+}
+
+.module-flow__step > :first-child { margin-top: 0; }
+.module-flow__step > :last-child { margin-bottom: 0; }
+
+/* Intro mapping (file -> module -> visualization) and how-it-works steps
+   (detect -> reshape -> render) share the same positional accent colors. */
+.module-flow__step--detect,
+.module-flow__step--file { border-top-color: #6495ED; }    /* blue */
+.module-flow__step--reshape,
+.module-flow__step--module { border-top-color: #9966CC; }  /* purple */
+.module-flow__step--render,
+.module-flow__step--component { border-top-color: #45B8AC; } /* teal */
+
+.module-flow__step--detect .twemoji,
+.module-flow__step--file .twemoji { color: #6495ED; }
+.module-flow__step--reshape .twemoji,
+.module-flow__step--module .twemoji { color: #9966CC; }
+.module-flow__step--render .twemoji,
+.module-flow__step--component .twemoji { color: #45B8AC; }
+
+/* Connecting arrows between steps (hidden on the last step and on mobile). */
+.module-flow__step:not(:last-child)::after {
+    content: "→";
+    position: absolute;
+    right: -1.25rem;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 1.1rem;
+    line-height: 1;
+    color: var(--md-default-fg-color--light);
+}
+
+.module-flow__opt {
+    font-size: 0.7em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--md-default-fg-color--light);
+}
+
+@media screen and (max-width: 44.9375em) {
+    .module-flow__step:not(:last-child)::after { content: none; }
+}
+
+/* Flat brand-color accents for the catalog intro cards (no gradients). */
+.cat-figure { color: #6495ED; }   /* blue */
+.cat-table { color: #45B8AC; }    /* teal */
+.cat-card { color: #9966CC; }     /* purple */
+.cat-advviz { color: #7A5DC7; }   /* violet */
+.cat-multiqc { color: #8BC34A; }  /* green */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ extra_css:
 # Extra JavaScript
 extra_javascript:
   - javascripts/triangular-animation.js
+  - javascripts/catalog-fullscreen.js
 
 # Markdown Extensions
 markdown_extensions:
@@ -239,20 +240,21 @@ nav:
       - nf-core:
           - ampliseq: pipeline-templates/nf-core/ampliseq.md
           - viralrecon: pipeline-templates/nf-core/viralrecon.md
+  - Modules: modules/index.md
   - Developer:
       - Overview: developer/README.md
       - Contributing: developer/contributing.md
       - Contributing Templates: developer/contributing-templates.md
-  - FAQ:
-      - Overview: FAQ/README.md
-      - General: FAQ/general.md
   - Roadmap: roadmap/README.md
   - Changelog: changelog/README.md
-  - Blog:
-      - blog/index.md
   - More:
       - Overview: more/README.md
       # - Stories: more/stories.md
+      - FAQ:
+          - Overview: FAQ/README.md
+          - General: FAQ/general.md
+      - Blog:
+          - blog/index.md
       - Funding: more/funding.md
       - Color Palette: more/palette.md
       - Animated Logo: animated-logo.md


### PR DESCRIPTION
## Summary
- Add a **Modules** page (`docs/modules/index.md`) embedding a theme-aware, live component catalog gallery of tool-to-component integrations, with a page-fill fullscreen toggle (`docs/javascripts/catalog-fullscreen.js` + styles in `extra.css`).
- Generate the gallery HTML (light + dark) on the fly in `deploy-docs.yaml` from the `depictio/depictio` source repo; the output is gitignored and never committed.
- Cross-link the new page from the Dashboard Components guide and restructure nav to nest FAQ/Blog under **More**.

## Notes
- A new `depictio_ref` workflow input lets the catalog build target a specific depictio ref (defaults to `main`).