### PR TITLE
docs(install): source the quick-start compose from the stable tag

### DIFF
--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -11,7 +11,7 @@ description: "Get started with Depictio by choosing the installation method that
 No git clone, no configuration file.
 
 ```bash title="Terminal" linenums="1"
-curl -LO https://raw.githubusercontent.com/depictio/depictio/main/docker-compose.yaml # (1)!
+curl -LO https://raw.githubusercontent.com/depictio/depictio/stable/docker-compose.yaml # (1)!
 docker compose up -d # (2)!
 ```
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -9,7 +9,7 @@ Up and running in two commands — no git clone, no configuration file needed.
 ### Step 1 — Download the compose file
 
 ```bash
-curl -LO https://raw.githubusercontent.com/depictio/depictio/main/docker-compose.yaml
+curl -LO https://raw.githubusercontent.com/depictio/depictio/stable/docker-compose.yaml
 ```
 
 ### Step 2 — Start


### PR DESCRIPTION
Companion to depictio/depictio#823.

The depictio repo now self-pins `docker-compose.yaml` to **every** released version (betas included), so `main`'s compose follows the latest beta between stable releases. Point the get-started `curl` at the **`stable` tag** instead of `main` so new users always download the last stable's self-pinned file.

Updated: `docs/installation/README.md`, `docs/installation/docker.md`.