### PR TITLE
ci: extract OpenAPI from the depictio-api image, not the dead monolith

### DIFF
--- a/.github/workflows/update-on-release.yaml
+++ b/.github/workflows/update-on-release.yaml
@@ -12,7 +12,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: depictio/depictio
+  # The monolithic depictio/depictio image was split into per-service images;
+  # the FastAPI app (and thus the OpenAPI schema) now lives in depictio-api.
+  IMAGE_NAME: depictio/depictio-api
 
 jobs:
   create-update-pr:

--- a/.github/workflows/update-on-release.yaml
+++ b/.github/workflows/update-on-release.yaml
@@ -58,8 +58,13 @@ jobs:
           # Generate OpenAPI schema directly without starting the server
           # This avoids the need for MongoDB and other dependencies
           echo "Generating OpenAPI specification..."
+          # Single-user mode relaxes the production secret checks (the Settings
+          # model otherwise rejects the default/unset MinIO password at import
+          # time). We only need the app object to call app.openapi(); no server,
+          # DB or real secrets are started.
           docker run --rm \
             -e DEPICTIO_CONTEXT=server \
+            -e DEPICTIO_AUTH_SINGLE_USER_MODE=true \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.image_tag }} \
             python -c "import json; from depictio.api.main import app; print(json.dumps(app.openapi(), indent=2))" \
             > docs/api/openapi.json

--- a/.github/workflows/update-on-release.yaml
+++ b/.github/workflows/update-on-release.yaml
@@ -58,13 +58,16 @@ jobs:
           # Generate OpenAPI schema directly without starting the server
           # This avoids the need for MongoDB and other dependencies
           echo "Generating OpenAPI specification..."
-          # Single-user mode relaxes the production secret checks (the Settings
-          # model otherwise rejects the default/unset MinIO password at import
-          # time). We only need the app object to call app.openapi(); no server,
-          # DB or real secrets are started.
+          # Importing depictio.api.main builds the Settings model, which in
+          # server context rejects an unset/default MinIO root password — even
+          # in single-user mode (that flag only relaxes the auth-password
+          # checks). Pass a throwaway strong password so the model validates;
+          # no server, DB or real secrets are started — we only need the app
+          # object to call app.openapi().
           docker run --rm \
             -e DEPICTIO_CONTEXT=server \
             -e DEPICTIO_AUTH_SINGLE_USER_MODE=true \
+            -e DEPICTIO_MINIO_ROOT_PASSWORD=openapi-extract-not-a-real-secret \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.image_tag }} \
             python -c "import json; from depictio.api.main import app; print(json.dumps(app.openapi(), indent=2))" \
             > docs/api/openapi.json


### PR DESCRIPTION
Companion to depictio/depictio#825 (which re-adds the release→docs notify).

The release→docs automation pulled `ghcr.io/depictio/depictio:<tag>` to extract the OpenAPI schema, but that **monolithic image no longer exists** — image builds were split into per-service images (`depictio-api`/`-worker`/`-viewer`). Every release update failed with `manifest unknown` (incl. the v1.0.1 catch-up dispatch).

The FastAPI app now ships in **`depictio-api`** (`Dockerfile.api` puts `/app/.venv/bin` on PATH, so the existing `python -c 'from depictio.api.main import app'` extraction works unchanged). Point `IMAGE_NAME` there.

Verified by dispatching this workflow from the branch with `version=v1.0.1`.