### PR TITLE
docs: v1.1.0 changelog and related feature docs

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -15,6 +15,42 @@ hide:
     to canonical. The 0.13.x patch series prepared the data-fetch and
     bundled-seed paths for this cutover.
 
+## **v1.1.0** (unreleased)
+
+!!! success "Minor release — self-adapting nf-core templates, ingestion report, render-path performance work"
+
+### Docker Images
+
+```bash
+ghcr.io/depictio/depictio:1.1.0
+```
+
+### **✨ New Features**
+
+* **Self-adapting nf-core templates** — single ampliseq and viralrecon templates adapt to the pipeline route (ITS / SIDLE / skip_qiime, Illumina / nanopore-ARTIC); irrelevant data collections, components and tabs are pruned automatically.
+* **Ingestion report** — viewer panel comparing template-expected vs ingested data collections with per-collection health and a dashboard health banner; new `/ingestion-report` and `/ingestion-health` endpoints.
+* **Component catalog** — browse the live [Depictio Modules](../modules/index.md) catalog mapping tool outputs to visualizations; `depictio-cli catalog preview` / `gallery` render components on bundled fixtures locally or export standalone HTML with `--out`.
+* **`depictio-cli run --dashboard-name`** — override a template's dashboard title at import without editing the template; SIDLE multiregion runs auto-detected from `params.json`.
+* **`DEPICTIO_SEED_PROJECTS`** — allowlist scoping which reference projects are seeded on boot.
+
+### **⚡ Performance**
+
+* **Rendering & caching** — Delta column projection, adaptive render offload, Polars-native figures, Arrow-IPC/LZ4 cache, and scatter downsampling (WebGL above 50k points), with new `offload_rendering` and `offload_size_threshold_bytes` settings. Reduces redundant work when building figures; not yet extensively benchmarked.
+
+### **🚀 Improvements**
+
+* **Project detail tabs** — Overview / Data Collections / Links / Ingestion, with a sortable data-collection table and clickable project badges.
+* **Dashboard logo** — used as the card thumbnail fallback.
+* **Codespaces** — single-project (iris) seed, reliable port forwarding, and deterministic single-user mode.
+
+### **🐛 Bug Fixes**
+
+* FastQC alpha-channel colorscales (`#RRGGBBAA`) now render; empty heatmap categories fold into "Unclassified".
+* Unparsed MultiQC modules and metadata-only tabs are hidden; a Delta schema-read failure falls back to a full load.
+* viralrecon coverage cards use the average instead of the median; compose shares the screenshots directory between worker and backend.
+
+---
+
 ## **[v1.0.1](https://github.com/depictio/depictio/releases/tag/v1.0.1)** (June 11, 2026)
 
 !!! success "Patch — zero-config quickstart hardening"

--- a/docs/depictio-cli/usage.md
+++ b/docs/depictio-cli/usage.md
@@ -128,6 +128,7 @@ depictio-cli run --project-config-path ./config.yaml
     | `--template` | `string` | `null` | Template ID (e.g. `nf-core/ampliseq/2.16.0`) |
     | `--data-root` | `path` | `null` | Root directory substituted for `{DATA_ROOT}` in template. Required when `--template` is set. |
     | `--project-name` | `string` | `null` | Custom project name (auto-generated from template if omitted) |
+    | `--dashboard-name` | `string` | `null` | Override the template's main dashboard title at import (the template file is left untouched). |
     | `--dashboard` | `path` | `null` | Override default dashboard(s) to import. Repeatable. |
     | `--skip-dashboard-import` | `flag` | `false` | Skip the automatic dashboard import step (Step 8) |
 
@@ -207,7 +208,7 @@ depictio-cli run \
   --skip-s3-check
 ```
 
-### 🍳 Recipe Commands
+### 🧑‍🍳 Recipe Commands
 
 <!-- prettier-ignore -->
 !!! info "Command Group: `depictio-cli recipe`"
@@ -626,6 +627,43 @@ depictio-cli dashboard export 6824cb3b89d2b72169309737 --config ~/.depictio/admi
 ---
 
 For more information about dashboard YAML format and workflows, see [Dashboard YAML Management](../features/yaml-sync.md).
+
+---
+
+### 🗂️ Catalog Commands
+
+<!-- prettier-ignore -->
+!!! info "Command Group: `depictio-cli catalog`"
+    Browse the bioinformatics tool→viz catalog by rendering its components on their bundled fixture data. Handy for previewing what a module produces before wiring it into a dashboard. For the live, hosted version see the [Depictio Modules](../modules/index.md) catalog.
+
+#### `catalog preview`
+
+Render a single catalog output on its fixture and serve it on a throwaway localhost server (nothing is written to disk). Pass `--out` to export a portable, self-contained HTML file instead.
+
+```bash
+# Serve an ephemeral preview (Ctrl-C to stop)
+depictio-cli catalog preview <output-id>
+
+# Export a standalone HTML file instead of serving
+depictio-cli catalog preview <output-id> --out preview.html
+```
+
+#### `catalog gallery`
+
+Same as `preview`, but renders the whole catalog as a browsable gallery.
+
+```bash
+depictio-cli catalog gallery
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--out`, `-o` | `path` | `null` | Export the self-contained HTML here instead of serving it |
+| `--port` | `int` | `0` | Port for the ephemeral server (`0` = auto) |
+| `--theme`, `-t` | `string` | `light` | Theme: `light` or `dark` |
+| `--no-open` | `flag` | `false` | Do not open a browser tab automatically |
+
+---
 
 ### 💾 Backup Commands
 

--- a/docs/features/dashboards.md
+++ b/docs/features/dashboards.md
@@ -174,6 +174,45 @@ After repositioning or resizing components, use the **Save Layout** button in th
 
 ---
 
+## :material-clipboard-check-outline: Ingestion Report & Health
+
+Dashboards created from a [pipeline template](../pipeline-templates/README.md) carry an
+**ingestion report** that compares the data collections the template *expected* against
+what was actually found and aggregated during the CLI scan. It answers "did all the data
+this dashboard needs actually land?" at a glance.
+
+### :material-magnify: What the report shows
+
+The report lists every expected data collection with a status:
+
+| Status | Meaning |
+| --- | --- |
+| :material-check-circle:{ style="color: #2e7d32" } **Identified** | Included in this configuration and files were found and/or aggregated. |
+| :material-alert-circle:{ style="color: #ef6c00" } **Found zero** | Included but nothing matched — no files identified and not aggregated. |
+| :material-minus-circle:{ style="color: #757575" } **Gated out** | Intentionally excluded by a template conditional or missing-file prune (not a gap). |
+
+Expand a row to see its files (or the Delta-table path once aggregated), and filter or
+group rows by status.
+
+### :material-heart-pulse: Health status & banner
+
+The report rolls up into a single project **health** value:
+
+- :material-check:{ style="color: #2e7d32" } **ok** — every required collection was identified.
+- :material-alert:{ style="color: #ef6c00" } **partial** — some optional collections are missing.
+- :material-close-octagon:{ style="color: #c62828" } **missing required** — a required collection is missing or empty.
+
+When a template-derived dashboard is missing or only partially has a required collection,
+a dismissible **health banner** appears above the dashboard. The full report is reachable
+from the **settings drawer** of any template-derived project.
+
+!!! note "Legacy projects"
+    The report relies on the expected-data-collection manifest frozen at template
+    resolution time. Projects created before this manifest existed fall back to the live
+    project state, where intentionally gated-out collections cannot be distinguished.
+
+---
+
 ## :material-share-variant: Sharing Dashboards
 
 ### :material-shield-account: Permissions

--- a/docs/features/performance.md
+++ b/docs/features/performance.md
@@ -1,0 +1,68 @@
+---
+title: "Performance & Scaling"
+icon: material/speedometer
+description: "Mechanisms Depictio uses in the render path to handle larger data collections."
+---
+
+# :material-speedometer: Performance & Scaling
+
+This page describes the mechanisms in Depictio's render path aimed at handling **larger
+data collections**, and the settings that let you tune them for your deployment.
+
+!!! note "Work in progress"
+    These changes target the render and caching paths to reduce redundant work; they are
+    recent and have **not yet been extensively benchmarked**, so this page describes *what
+    each mechanism does* rather than promising specific speed-ups. Real-world figures will
+    be added as they are measured.
+
+## Rendering
+
+Most of the work happens server-side, in a Polars + Delta Lake + Celery pipeline, so the
+browser receives compact, pre-rendered payloads rather than raw data.
+
+- **Column projection on Delta tables** — figures and cards read only the columns they
+  need from the Delta table rather than the full frame, which reduces I/O on wide tables.
+- **Polars-native figure building** — figures are built directly from Polars frames,
+  avoiding a second in-memory copy of the frame via pandas.
+- **Scatter downsampling + WebGL** — scatter-type figures above **50,000 points** are
+  downsampled and switched to WebGL rendering, intended to keep large scatter plots
+  renderable in the browser rather than sending a multi-megabyte trace.
+- **Server-side table pagination** — tables stream rows on demand (capped per request)
+  and mount lazily as they scroll into view, so large tables aren't loaded into the
+  browser all at once.
+- **Compressed responses** — large figure/table JSON is gzip-compressed in transit.
+
+## Render offload
+
+By default Depictio renders figures **adaptively**: cheap, interactive figures render
+inline on the API worker, while heavy figures (large frames, MultiQC) are offloaded to
+Celery workers so the API stays responsive under concurrent load.
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `offload_rendering` | `true` | Offload heavy figure rendering to Celery workers instead of building them on the API worker thread. |
+| `offload_size_threshold_bytes` | `50 MB` | Frame size above which a render is offloaded rather than run inline. |
+
+These are standard Depictio settings — see the
+[environment reference](../installation/env-reference.md) for how to set them
+(`DEPICTIO_...` environment variables or the settings file).
+
+## Caching
+
+- **Arrow IPC (LZ4) cache** — cached Polars frames are stored with Arrow IPC + LZ4
+  compression in Redis, a more compact serialization than the previous pickle format.
+  Frames above the per-item cap are skipped rather than cached, so large frames don't
+  silently bloat Redis.
+- **MultiQC resident report** — parsed MultiQC reports are kept resident in the worker
+  process across renders, so prewarming a dashboard's MultiQC figures no longer
+  re-deserializes the full report for every plot.
+
+## Tuning for your deployment
+
+- **Scale workers, not the API** — heavy rendering is CPU-bound. Add Celery worker
+  concurrency / replicas (and RAM, since each worker holds its own frame copies) rather
+  than overloading the API process.
+- **Keep `offload_rendering` on** for multi-user deployments serving large data
+  collections; inline rendering only makes sense for small single-user setups.
+- **Project your columns** — narrower data collections (only the columns your components
+  use) mean less data read and cached.

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -98,7 +98,7 @@ docker compose up -d
 
     ---
 
-    Launch a temporary cloud workspace with Depictio pre-configured — no local setup required.
+    Launch a temporary cloud workspace with Depictio pre-configured — no local setup required. Boots in single-user mode with the Iris reference project pre-seeded and the viewer opened automatically.
 
     [:octicons-arrow-right-24: Open in Codespaces](https://codespaces.new/depictio/depictio)
 

--- a/docs/installation/env-reference.md
+++ b/docs/installation/env-reference.md
@@ -457,6 +457,7 @@ Top-level application settings including context configuration.
 |----------|---------|-------------|
 | `DEPICTIO_CONTEXT` | `server` | - |
 | `DEPICTIO_DISABLE_EXAMPLE_DASHBOARDS` | `false` | Skip seeding the bundled reference projects (Iris, Penguins, Advanced Visualisations, nf-core/ampliseq, nf-core/viralrecon) and their dashboards on API startup. Opt-in: default preserves current behaviour. |
+| `DEPICTIO_SEED_PROJECTS` | _(empty = all)_ | Comma-separated allowlist of bundled reference datasets to seed on startup (e.g. `iris` or `iris,penguins`). Empty seeds all of them. Ignored when `DEPICTIO_DISABLE_EXAMPLE_DASHBOARDS=true` (that takes precedence and seeds none). Used by the devcontainer/Codespaces setup to seed only `iris` for a faster boot. |
 | `DEPICTIO_WALKTHROUGH_DISABLED` | `false` | Hide the onboarding walkthrough overlay for every user. Useful for embedded iframes, staging envs used for screenshot capture, and demos with their own narration. `DEPICTIO_DEV_MODE=true` also suppresses it. |
 
 ---

--- a/docs/pipeline-templates/README.md
+++ b/docs/pipeline-templates/README.md
@@ -1,8 +1,9 @@
 ---
+title: Templates
 icon: material/layers-outline
 ---
 
-# Templates
+# Depictio Templates
 
 Templates are pre-packaged project configurations that set up a complete bioinformatics analysis project — dashboards included — with a single command.
 
@@ -12,7 +13,73 @@ depictio-cli run \
   --data-root /data/my_ampliseq_run
 ```
 
-That's it. Depictio resolves your data directory, runs all data transformations, and imports ready-to-use dashboards automatically.
+---
+
+## Available templates
+
+<div class="template-cards">
+
+  <a class="template-card" href="nf-core/ampliseq/">
+    <div class="template-card-logo">
+      <img class="nf-core-dark" src="https://raw.githubusercontent.com/nf-core/ampliseq/master/docs/images/nf-core-ampliseq_logo_dark.png" alt="nf-core/ampliseq">
+      <img class="nf-core-light" src="https://raw.githubusercontent.com/nf-core/ampliseq/master/docs/images/nf-core-ampliseq_logo_light.png" alt="nf-core/ampliseq">
+    </div>
+    <div class="template-card-body">
+      <p class="template-card-desc">16S · ITS · CO1 · 18S amplicon sequencing across Illumina, PacBio, and IonTorrent.</p>
+      <div class="template-card-meta">
+        <span class="template-version">v2.16.0</span>
+        <span class="template-status-reviewed"><i class="mdi mdi-check-circle-outline" style="vertical-align:-1px;"></i> Reviewed</span>
+      </div>
+    </div>
+  </a>
+
+  <a class="template-card" href="nf-core/viralrecon/">
+    <div class="template-card-logo">
+      <img class="nf-core-dark" src="https://raw.githubusercontent.com/nf-core/viralrecon/master/docs/images/nf-core-viralrecon_logo_dark.png" alt="nf-core/viralrecon">
+      <img class="nf-core-light" src="https://raw.githubusercontent.com/nf-core/viralrecon/master/docs/images/nf-core-viralrecon_logo_light.png" alt="nf-core/viralrecon">
+    </div>
+    <div class="template-card-body">
+      <p class="template-card-desc">Viral assembly and variant calling — SARS-CoV-2 and other genomes via the nf-core reference config.</p>
+      <div class="template-card-meta">
+        <span class="template-version">v3.0.0</span>
+        <span class="template-status-reviewed"><i class="mdi mdi-check-circle-outline" style="vertical-align:-1px;"></i> Reviewed</span>
+      </div>
+    </div>
+  </a>
+
+</div>
+
+---
+
+## Status levels
+
+<div class="status-cards">
+
+  <div class="status-card status-certified">
+    <div class="status-card-header">
+      <i class="mdi mdi-shield-check status-icon"></i>
+      <span class="status-title">Certified</span>
+    </div>
+    <p class="status-desc">Validated by the <strong>pipeline lead developer</strong>. Highest trust level.</p>
+  </div>
+
+  <div class="status-card status-reviewed">
+    <div class="status-card-header">
+      <i class="mdi mdi-check-circle-outline status-icon"></i>
+      <span class="status-title">Reviewed</span>
+    </div>
+    <p class="status-desc">Tested, CI passes, reviewed by the Depictio team or community.</p>
+  </div>
+
+  <div class="status-card status-experimental">
+    <div class="status-card-header">
+      <i class="mdi mdi-flask-outline status-icon"></i>
+      <span class="status-title">Experimental</span>
+    </div>
+    <p class="status-desc">Shared as-is. Feedback and PRs welcome.</p>
+  </div>
+
+</div>
 
 ---
 
@@ -26,33 +93,6 @@ A template bundles:
 - :material-link: **Cross-DC links** — enable interactive filtering across data collections
 
 See [Template System Reference](../usage/projects/templates.md) for the YAML format and resolution mechanics, and [Recipes](../usage/projects/recipes.md) for how data transformations work.
-
----
-
-## Status levels
-
-Each template carries a status reflecting its review level.
-
-:material-shield-check:{ style="color:#4CAF50" } **Certified** — Validated by the **pipeline lead developer**. Highest trust.
-
-:material-check-circle-outline:{ style="color:#2196F3" } **Reviewed** — Tested, CI passes, reviewed by Depictio team or community.
-
-:material-flask-outline:{ style="color:#FF9800" } **Experimental** — Shared as-is. Feedback and PRs welcome.
-
----
-
-## Available templates
-
-<div style="display:flex;gap:16px;flex-wrap:wrap;">
-  <a href="nf-core/ampliseq/" style="text-decoration:none;color:inherit;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;border:1px solid #ddd;border-radius:16px;padding:32px 40px;width:280px;transition:box-shadow 0.2s;" onmouseover="this.style.boxShadow='0 4px 12px rgba(0,0,0,0.1)'" onmouseout="this.style.boxShadow='none'">
-    <img src="https://raw.githubusercontent.com/nf-core/ampliseq/master/docs/images/nf-core-ampliseq_logo_light.png" alt="nf-core/ampliseq" style="height:64px;">
-    <span style="background:#2196F3;color:#fff;padding:4px 14px;border-radius:12px;font-size:0.85em;font-weight:600;"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px;"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>Reviewed</span>
-  </a>
-  <a href="nf-core/viralrecon/" style="text-decoration:none;color:inherit;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;border:1px solid #ddd;border-radius:16px;padding:32px 40px;width:280px;transition:box-shadow 0.2s;" onmouseover="this.style.boxShadow='0 4px 12px rgba(0,0,0,0.1)'" onmouseout="this.style.boxShadow='none'">
-    <img src="https://raw.githubusercontent.com/nf-core/viralrecon/master/docs/images/nf-core-viralrecon_logo_light.png" alt="nf-core/viralrecon" style="height:64px;">
-    <span style="background:#2196F3;color:#fff;padding:4px 14px;border-radius:12px;font-size:0.85em;font-weight:600;"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px;"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>Reviewed</span>
-  </a>
-</div>
 
 ---
 

--- a/docs/pipeline-templates/nf-core/_generated/ampliseq-2.14.0.md
+++ b/docs/pipeline-templates/nf-core/_generated/ampliseq-2.14.0.md
@@ -6,6 +6,10 @@
 .gtd-badge{display:inline-block;padding:0 .5em;border-radius:10px;font-size:.78em;font-weight:600;line-height:1.5;white-space:nowrap;}
 .gtd-scan{background:#eef1fb;color:#3949ab;}
 .gtd-transformed{background:#e6f7f5;color:#2a8c82;}
+.gtd-direct{background:#eaf2ff;color:#2563c9;}
+.gtd-derived{background:#f3e8fd;color:#8e44ad;}
+.gtd-recipe{background:#fbe9f1;color:#b4337a;}
+.gtd-file{background:#eef0f2;color:#5a6573;}
 .gtd-opt{background:#fff6e6;color:#b9770e;}
 .gtd-req{background:#e9f7ef;color:#1e8e5a;}
 .gtd-plus-chip{background:#e9f7ef;color:#1e8e5a;}
@@ -21,6 +25,8 @@
    only the other columns' long paths may wrap. */
 .md-typeset table td:first-child{white-space:nowrap;}
 .md-typeset table td:not(:first-child) code{overflow-wrap:anywhere;}
+/* Reads-column paths: smaller monospace + wrap so long scan targets keep the row tidy. */
+.md-typeset table code.gtd-path{font-size:.62rem;overflow-wrap:anywhere;}
 .gtd-mtx{margin:.8rem 0;}
 .gtd-mtx table{border-collapse:separate;border-spacing:0;font-size:.7rem;}
 .gtd-mtx th,.gtd-mtx td{border:1px solid var(--md-default-fg-color--lightest,#e6e6e6);padding:2px 5px;text-align:center;}
@@ -51,7 +57,7 @@
 
 ### Template variables
 
-Variables you provide when running the template — `DATA_ROOT` via `--data-root`, the rest via `--var NAME=value`:
+`DATA_ROOT` (via `--data-root`) is the only required input. The rest mirror the pipeline's own nf-core parameters and are **auto-derived from the run's `params.json`** — pass `--var NAME=value` only to override what the run recorded:
 
 | Variable | Required | Description |
 |---|:--:|---|
@@ -61,18 +67,20 @@ Variables you provide when running the template — `DATA_ROOT` via `--data-root
 
 ### Data collections
 
-8 data collections — <span class="gtd-badge gtd-req">7 required</span> <span class="gtd-badge gtd-opt">1 optional</span>.
+8 data collections — <span class="gtd-badge gtd-req">7 required</span> <span class="gtd-badge gtd-opt">1 optional</span> · <span class="gtd-badge gtd-direct">7 direct</span> <span class="gtd-badge gtd-derived">1 derived</span>.
 
-| Tag | Type | Source | Recipe / scan target | Status |
-|---|---|---|---|:--:|
-| `multiqc_data` | MultiQC | <span class="gtd-badge gtd-scan">scan</span> | `multiqc/multiqc_data/multiqc.parquet` | <span class="gtd-badge gtd-req">required</span> |
-| `samplesheet` | Table | <span class="gtd-badge gtd-scan">scan</span> | `{SAMPLESHEET_FILE}` | <span class="gtd-badge gtd-req">required</span> |
-| `metadata` | Table | <span class="gtd-badge gtd-scan">scan</span> | `{METADATA_FILE}` | <span class="gtd-badge gtd-opt">optional</span> |
-| `alpha_diversity` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/alpha_diversity.py` | <span class="gtd-badge gtd-req">required</span> |
-| `alpha_rarefaction` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/alpha_rarefaction.py` | <span class="gtd-badge gtd-req">required</span> |
-| `taxonomy_composition` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/taxonomy_composition.py` | <span class="gtd-badge gtd-req">required</span> |
-| `taxonomy_rel_abundance` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/taxonomy_rel_abundance.py` | <span class="gtd-badge gtd-req">required</span> |
-| `ancombc_results` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/ancombc.py` | <span class="gtd-badge gtd-req">required</span> |
+**Origin** tells you whether a collection is *real pipeline data* or a reshape of it: <span class="gtd-badge gtd-direct">direct</span> = a pipeline output (scanned, or a recipe that reads raw files); <span class="gtd-badge gtd-derived">derived</span> = a recipe that reshapes one or more *direct* collections into the layout a visualization needs (no new measurement). **Reads** shows what produces it: a <span class="gtd-badge gtd-recipe">recipe</span> `.py` transform, or a raw <span class="gtd-badge gtd-file">file</span> scanned off disk. (A `direct` collection can still have a recipe — one that merely parses/cleans the raw file; `derived` means the recipe reshapes another collection.)
+
+| Tag | Origin | Type | Reads | Status |
+|---|:--:|---|---|:--:|
+| `multiqc_data` | <span class="gtd-badge gtd-direct">direct</span> | <img src="https://raw.githubusercontent.com/MultiQC/logo/main/logos/multiqc_icon_color.svg" alt="MultiQC" width="14" style="vertical-align:text-bottom;"> MultiQC | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">multiqc/multiqc_data/multiqc.parquet</code> | <span class="gtd-badge gtd-req">required</span> |
+| `samplesheet` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">{SAMPLESHEET_FILE}</code> | <span class="gtd-badge gtd-req">required</span> |
+| `metadata` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">{METADATA_FILE}</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `alpha_diversity` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/alpha_diversity.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `alpha_rarefaction` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/alpha_rarefaction.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `taxonomy_composition` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/taxonomy_composition.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `taxonomy_rel_abundance` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/taxonomy_rel_abundance.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `ancombc_results` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/ancombc.py</code> | <span class="gtd-badge gtd-req">required</span> |
 
 ### Conditional routes
 

--- a/docs/pipeline-templates/nf-core/_generated/ampliseq-2.16.0.md
+++ b/docs/pipeline-templates/nf-core/_generated/ampliseq-2.16.0.md
@@ -6,6 +6,10 @@
 .gtd-badge{display:inline-block;padding:0 .5em;border-radius:10px;font-size:.78em;font-weight:600;line-height:1.5;white-space:nowrap;}
 .gtd-scan{background:#eef1fb;color:#3949ab;}
 .gtd-transformed{background:#e6f7f5;color:#2a8c82;}
+.gtd-direct{background:#eaf2ff;color:#2563c9;}
+.gtd-derived{background:#f3e8fd;color:#8e44ad;}
+.gtd-recipe{background:#fbe9f1;color:#b4337a;}
+.gtd-file{background:#eef0f2;color:#5a6573;}
 .gtd-opt{background:#fff6e6;color:#b9770e;}
 .gtd-req{background:#e9f7ef;color:#1e8e5a;}
 .gtd-plus-chip{background:#e9f7ef;color:#1e8e5a;}
@@ -21,6 +25,8 @@
    only the other columns' long paths may wrap. */
 .md-typeset table td:first-child{white-space:nowrap;}
 .md-typeset table td:not(:first-child) code{overflow-wrap:anywhere;}
+/* Reads-column paths: smaller monospace + wrap so long scan targets keep the row tidy. */
+.md-typeset table code.gtd-path{font-size:.62rem;overflow-wrap:anywhere;}
 .gtd-mtx{margin:.8rem 0;}
 .gtd-mtx table{border-collapse:separate;border-spacing:0;font-size:.7rem;}
 .gtd-mtx th,.gtd-mtx td{border:1px solid var(--md-default-fg-color--lightest,#e6e6e6);padding:2px 5px;text-align:center;}
@@ -51,7 +57,7 @@
 
 ### Template variables
 
-Variables you provide when running the template — `DATA_ROOT` via `--data-root`, the rest via `--var NAME=value`:
+`DATA_ROOT` (via `--data-root`) is the only required input. The rest mirror the pipeline's own nf-core parameters and are **auto-derived from the run's `params.json`** — pass `--var NAME=value` only to override what the run recorded:
 
 | Variable | Required | Description |
 |---|:--:|---|
@@ -60,38 +66,45 @@ Variables you provide when running the template — `DATA_ROOT` via `--data-root
 | `METADATA_FILE` | — | Path to sample metadata TSV (--metadata in ampliseq run). Optional. All non-ID columns become annotations. |
 | `METADATA_ID_COL` | — | Metadata sample-ID column name (links join on it). Auto-detected as the first metadata column; defaults to 'sample'. |
 | `GROUP_COL` | — | Metadata column for grouping/facetting in dashboards. Auto-detected as first annotation column if not provided. |
+| `SKIP_QIIME` | — | nf --skip_qiime. ITS/sintax runs (true) produce no QIIME2 outputs. Auto-derived from params.json. |
+| `SKIP_TAXONOMY` | — | nf --skip_taxonomy. When true, qiime2/{barplot,rel_abundance_tables,taxonomy}/ are absent. Auto-derived from params.json. |
+| `SKIP_ALPHA_RAREFACTION` | — | nf --skip_alpha_rarefaction. When true, qiime2/alpha-rarefaction/ is absent. Auto-derived from params.json. |
+| `ANCOMBC` | — | nf --ancombc (positive opt-in). When false (default), no qiime2/ancombc/ output exists, so the differential-abundance DCs are pruned. Auto-derived from params.json. |
+| `MULTIREGION` | — | nf --multiregion (path; present on SIDLE multi-region runs). When set, per-region ASVs are reconstructed under sidle/ and the QIIME2 diversity/phylogeny/ANCOM-BC DCs are absent. Auto-derived from params.json. |
 
-**Auto-detected** (set from the run's metadata / `params.json`; the route flags drive *Conditional routes* below): `GROUP_COL_DISPLAY`, `ANNOTATION_COLS`, `IS_MULTIREGION`, `SKIP_TAXONOMY`, `SKIP_ALPHA_RAREFACTION`, `SKIP_ANCOM`
+**Auto-detected** (set from the run's metadata / `params.json`; the route flags drive *Conditional routes* below): `GROUP_COL_DISPLAY`, `ANNOTATION_COLS`
 
 ### Data collections
 
-23 data collections — <span class="gtd-badge gtd-req">11 required</span> <span class="gtd-badge gtd-opt">12 optional</span>.
+23 data collections — <span class="gtd-badge gtd-req">11 required</span> <span class="gtd-badge gtd-opt">12 optional</span> · <span class="gtd-badge gtd-direct">9 direct</span> <span class="gtd-badge gtd-derived">14 derived</span>.
 
-| Tag | Type | Source | Recipe / scan target | Status |
-|---|---|---|---|:--:|
-| `multiqc_data` | MultiQC | <span class="gtd-badge gtd-scan">scan</span> | `multiqc/multiqc_data/multiqc.parquet` | <span class="gtd-badge gtd-req">required</span> |
-| `samplesheet` | Table | <span class="gtd-badge gtd-scan">scan</span> | `{SAMPLESHEET_FILE}` | <span class="gtd-badge gtd-req">required</span> |
-| `metadata` | Table | <span class="gtd-badge gtd-scan">scan</span> | `{METADATA_FILE}` | <span class="gtd-badge gtd-opt">optional</span> |
-| `alpha_rarefaction` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/alpha_rarefaction.py` | <span class="gtd-badge gtd-req">required</span> |
-| `taxonomy_composition` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/taxonomy_composition.py` | <span class="gtd-badge gtd-req">required</span> |
-| `taxonomy_rel_abundance` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/taxonomy_rel_abundance.py` | <span class="gtd-badge gtd-req">required</span> |
-| `sintax_rel_abundance` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/sintax_rel_abundance.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `taxonomy_heatmap` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/taxonomy_heatmap.py` | <span class="gtd-badge gtd-req">required</span> |
-| `ancombc_results` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/ancombc.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `stacked_taxonomy_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/stacked_taxonomy_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `embedding_pcoa` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/embedding_pcoa.py` | <span class="gtd-badge gtd-req">required</span> |
-| `rarefaction_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/rarefaction_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `alpha_diversity_multi_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `qiime2/alpha_diversity_multi_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `complex_heatmap_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/complex_heatmap_canonical.py` | <span class="gtd-badge gtd-req">required</span> |
-| `sunburst_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/sunburst_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `sankey_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/sankey_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `upset_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/upset_canonical.py` | <span class="gtd-badge gtd-req">required</span> |
-| `ma_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/ma_canonical.py` | <span class="gtd-badge gtd-req">required</span> |
-| `bray_curtis_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/bray_curtis_canonical.py` | <span class="gtd-badge gtd-req">required</span> |
-| `phylogenetic_tree_canonical` | phylogeny | <span class="gtd-badge gtd-scan">scan</span> | `{DATA_ROOT}/qiime2/phylogenetic_tree/tree.nwk` | <span class="gtd-badge gtd-opt">optional</span> |
-| `phylogenetic_tree_metadata_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/tree_metadata_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `sidle_reconstructed` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/sidle_reconstructed.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `sidle_reconstruction_qc` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/ampliseq/sidle_reconstruction_qc.py` | <span class="gtd-badge gtd-opt">optional</span> |
+**Origin** tells you whether a collection is *real pipeline data* or a reshape of it: <span class="gtd-badge gtd-direct">direct</span> = a pipeline output (scanned, or a recipe that reads raw files); <span class="gtd-badge gtd-derived">derived</span> = a recipe that reshapes one or more *direct* collections into the layout a visualization needs (no new measurement). **Reads** shows what produces it: a <span class="gtd-badge gtd-recipe">recipe</span> `.py` transform, or a raw <span class="gtd-badge gtd-file">file</span> scanned off disk. (A `direct` collection can still have a recipe — one that merely parses/cleans the raw file; `derived` means the recipe reshapes another collection.)
+
+| Tag | Origin | Type | Reads | Status |
+|---|:--:|---|---|:--:|
+| `multiqc_data` | <span class="gtd-badge gtd-direct">direct</span> | <img src="https://raw.githubusercontent.com/MultiQC/logo/main/logos/multiqc_icon_color.svg" alt="MultiQC" width="14" style="vertical-align:text-bottom;"> MultiQC | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">multiqc/multiqc_data/multiqc.parquet</code> | <span class="gtd-badge gtd-req">required</span> |
+| `samplesheet` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">{SAMPLESHEET_FILE}</code> | <span class="gtd-badge gtd-req">required</span> |
+| `metadata` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">{METADATA_FILE}</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `alpha_rarefaction` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/alpha_rarefaction.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `taxonomy_composition` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/taxonomy_composition.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `taxonomy_rel_abundance` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/taxonomy_rel_abundance.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `sintax_rel_abundance` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/sintax_rel_abundance.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `taxonomy_heatmap` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/taxonomy_heatmap.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `ancombc_results` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/ancombc.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `stacked_taxonomy_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/stacked_taxonomy_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `embedding_pcoa` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/embedding_pcoa.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `rarefaction_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/rarefaction_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `alpha_diversity_multi_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">qiime2/alpha_diversity_multi_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `complex_heatmap_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/complex_heatmap_canonical.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `sunburst_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/sunburst_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `sankey_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/sankey_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `upset_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/upset_canonical.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `ma_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/ma_canonical.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `bray_curtis_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/bray_curtis_canonical.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `phylogenetic_tree_canonical` | <span class="gtd-badge gtd-direct">direct</span> | :material-graph-outline: phylogeny | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">{DATA_ROOT}/qiime2/phylogenetic_tree/tree.nwk</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `phylogenetic_tree_metadata_canonical` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/tree_metadata_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `sidle_reconstructed` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/sidle_reconstructed.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `sidle_reconstruction_qc` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/ampliseq/sidle_reconstruction_qc.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
 
 ### Conditional routes
 
@@ -101,27 +114,27 @@ Rows are data collections; columns are the variables you set or `params.json` fl
 
 <div class="gtd-mtx scroll">
 <table>
-<thead><tr><th class="dc">Data collection</th><th><code>METADATA_FILE</code></th><th><code>SKIP_QIIME</code></th><th><code>IS_MULTIREGION</code></th><th><code>SKIP_TAXONOMY</code></th><th><code>SKIP_ALPHA_RAREFACTION</code></th><th><code>SKIP_ANCOM</code></th></tr></thead>
+<thead><tr><th class="dc">Data collection</th><th><code>METADATA_FILE</code></th><th><code>SKIP_QIIME=true</code></th><th><code>SKIP_QIIME=false</code></th><th><code>MULTIREGION</code></th><th><code>SKIP_TAXONOMY=true</code></th><th><code>SKIP_ALPHA_RAREFACTION=true</code></th><th><code>ANCOMBC=false</code></th></tr></thead>
 <tbody>
-<tr><th class="dc"><code>metadata</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><th class="dc"><code>alpha_rarefaction</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td></td><td class="minus" title="removed when SKIP_ALPHA_RAREFACTION is set">−</td><td></td></tr>
-<tr><th class="dc"><code>taxonomy_composition</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td></td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>taxonomy_rel_abundance</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>sintax_rel_abundance</code></th><td></td><td class="plus" title="included only when SKIP_QIIME is set">+</td><td></td><td></td><td></td><td></td></tr>
-<tr><th class="dc"><code>taxonomy_heatmap</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>ancombc_results</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td class="minus" title="removed when SKIP_ANCOM is set">−</td></tr>
-<tr><th class="dc"><code>stacked_taxonomy_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>embedding_pcoa</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>rarefaction_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td></td><td class="minus" title="removed when SKIP_ALPHA_RAREFACTION is set">−</td><td></td></tr>
-<tr><th class="dc"><code>alpha_diversity_multi_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td></td><td class="minus" title="removed when SKIP_ALPHA_RAREFACTION is set">−</td><td></td></tr>
-<tr><th class="dc"><code>complex_heatmap_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>sunburst_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>sankey_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>upset_canonical</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>ma_canonical</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td class="minus" title="removed when SKIP_ANCOM is set">−</td></tr>
-<tr><th class="dc"><code>bray_curtis_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY is set">−</td><td></td><td></td></tr>
-<tr><th class="dc"><code>phylogenetic_tree_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td></td><td></td><td></td></tr>
-<tr><th class="dc"><code>phylogenetic_tree_metadata_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME is set">−</td><td class="minus" title="removed when IS_MULTIREGION is set">−</td><td></td><td></td><td></td></tr>
+<tr><th class="dc"><code>metadata</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><th class="dc"><code>alpha_rarefaction</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td></td><td class="minus" title="removed when SKIP_ALPHA_RAREFACTION=true">−</td><td></td></tr>
+<tr><th class="dc"><code>taxonomy_composition</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td></td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>taxonomy_rel_abundance</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>sintax_rel_abundance</code></th><td></td><td></td><td class="minus" title="removed when SKIP_QIIME=false">−</td><td></td><td></td><td></td><td></td></tr>
+<tr><th class="dc"><code>taxonomy_heatmap</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>ancombc_results</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td class="minus" title="removed when ANCOMBC=false">−</td></tr>
+<tr><th class="dc"><code>stacked_taxonomy_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>embedding_pcoa</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>rarefaction_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td></td><td class="minus" title="removed when SKIP_ALPHA_RAREFACTION=true">−</td><td></td></tr>
+<tr><th class="dc"><code>alpha_diversity_multi_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td></td><td class="minus" title="removed when SKIP_ALPHA_RAREFACTION=true">−</td><td></td></tr>
+<tr><th class="dc"><code>complex_heatmap_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>sunburst_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>sankey_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>upset_canonical</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>ma_canonical</code></th><td class="plus" title="included only when METADATA_FILE is set">+</td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td class="minus" title="removed when ANCOMBC=false">−</td></tr>
+<tr><th class="dc"><code>bray_curtis_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td class="minus" title="removed when SKIP_TAXONOMY=true">−</td><td></td><td></td></tr>
+<tr><th class="dc"><code>phylogenetic_tree_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td></td><td></td><td></td></tr>
+<tr><th class="dc"><code>phylogenetic_tree_metadata_canonical</code></th><td></td><td class="minus" title="removed when SKIP_QIIME=true">−</td><td></td><td class="minus" title="removed when MULTIREGION is set">−</td><td></td><td></td><td></td></tr>
 </tbody></table></div>
 
 ### Cross-DC links

--- a/docs/pipeline-templates/nf-core/_generated/viralrecon-3.0.0.md
+++ b/docs/pipeline-templates/nf-core/_generated/viralrecon-3.0.0.md
@@ -6,6 +6,10 @@
 .gtd-badge{display:inline-block;padding:0 .5em;border-radius:10px;font-size:.78em;font-weight:600;line-height:1.5;white-space:nowrap;}
 .gtd-scan{background:#eef1fb;color:#3949ab;}
 .gtd-transformed{background:#e6f7f5;color:#2a8c82;}
+.gtd-direct{background:#eaf2ff;color:#2563c9;}
+.gtd-derived{background:#f3e8fd;color:#8e44ad;}
+.gtd-recipe{background:#fbe9f1;color:#b4337a;}
+.gtd-file{background:#eef0f2;color:#5a6573;}
 .gtd-opt{background:#fff6e6;color:#b9770e;}
 .gtd-req{background:#e9f7ef;color:#1e8e5a;}
 .gtd-plus-chip{background:#e9f7ef;color:#1e8e5a;}
@@ -21,6 +25,8 @@
    only the other columns' long paths may wrap. */
 .md-typeset table td:first-child{white-space:nowrap;}
 .md-typeset table td:not(:first-child) code{overflow-wrap:anywhere;}
+/* Reads-column paths: smaller monospace + wrap so long scan targets keep the row tidy. */
+.md-typeset table code.gtd-path{font-size:.62rem;overflow-wrap:anywhere;}
 .gtd-mtx{margin:.8rem 0;}
 .gtd-mtx table{border-collapse:separate;border-spacing:0;font-size:.7rem;}
 .gtd-mtx th,.gtd-mtx td{border:1px solid var(--md-default-fg-color--lightest,#e6e6e6);padding:2px 5px;text-align:center;}
@@ -51,55 +57,66 @@
 
 ### Template variables
 
-Variables you provide when running the template — `DATA_ROOT` via `--data-root`, the rest via `--var NAME=value`:
+`DATA_ROOT` (via `--data-root`) is the only required input. The rest mirror the pipeline's own nf-core parameters and are **auto-derived from the run's `params.json`** — pass `--var NAME=value` only to override what the run recorded:
 
 | Variable | Required | Description |
 |---|:--:|---|
 | `DATA_ROOT` | ✓ | Root directory containing viralrecon pipeline output (multiqc/, variants/) |
-
-**Auto-detected** (set from the run's metadata / `params.json`; the route flags drive *Conditional routes* below): `IS_NANOPORE`
+| `PLATFORM` | — | nf --platform: 'illumina' (ivar) or 'nanopore' (ARTIC/clair3). Auto-derived from params.json; override with --var PLATFORM=nanopore. |
+| `PROTOCOL` | — | nf --protocol: 'amplicon' or 'metagenomic'. Metagenomic runs have no amplicon mosdepth outputs. Auto-derived from params.json. |
+| `VARIANT_CALLER` | — | nf --variant_caller: 'ivar' (amplicon default) or 'bcftools' (metagenomic default). Repoints the consensus lineage/clade outputs at variants/<caller>/. Auto-derived from params.json. |
+| `SKIP_PANGOLIN` | — | nf --skip_pangolin. When true, Pangolin lineage outputs are absent. Auto-derived from params.json. |
+| `SKIP_NEXTCLADE` | — | nf --skip_nextclade. When true, Nextclade clade outputs are absent. Auto-derived from params.json. |
+| `SKIP_VARIANTS` | — | nf --skip_variants. When true, all variant calling AND read mapping are skipped (no variants, no mosdepth coverage). Auto-derived from params.json. |
+| `SKIP_VARIANTS_LONG_TABLE` | — | nf --skip_variants_long_table. When true, the per-variant long table is absent. Auto-derived from params.json. |
+| `SKIP_MOSDEPTH` | — | nf --skip_mosdepth. When true, amplicon/genome coverage plots are absent. Auto-derived from params.json. |
 
 ### Data collections
 
-14 data collections — <span class="gtd-badge gtd-req">2 required</span> <span class="gtd-badge gtd-opt">12 optional</span>.
+14 data collections — <span class="gtd-badge gtd-req">2 required</span> <span class="gtd-badge gtd-opt">12 optional</span> · <span class="gtd-badge gtd-direct">8 direct</span> <span class="gtd-badge gtd-derived">6 derived</span>.
 
-| Tag | Type | Source | Recipe / scan target | Status |
-|---|---|---|---|:--:|
-| `multiqc_data` | MultiQC | <span class="gtd-badge gtd-scan">scan</span> | `multiqc/multiqc_data/multiqc.parquet` | <span class="gtd-badge gtd-req">required</span> |
-| `summary_metrics` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `multiqc/summary_metrics.py` | <span class="gtd-badge gtd-req">required</span> |
-| `variants_long` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `ivar/variants_long.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `pangolin_lineages` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `pangolin/pangolin_lineages.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `nextclade_results` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nextclade/nextclade_results.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `mosdepth_amplicon_coverage` | Table | <span class="gtd-badge gtd-scan">scan</span> | `variants/bowtie2/mosdepth/amplicon/all_samples.mosdepth.coverage.tsv` | <span class="gtd-badge gtd-opt">optional</span> |
-| `mosdepth_genome_coverage` | Table | <span class="gtd-badge gtd-scan">scan</span> | `variants/bowtie2/mosdepth/genome/all_samples.mosdepth.coverage.tsv` | <span class="gtd-badge gtd-opt">optional</span> |
-| `mosdepth_amplicon_heatmap` | Table | <span class="gtd-badge gtd-scan">scan</span> | `variants/bowtie2/mosdepth/amplicon/all_samples.mosdepth.heatmap.tsv` | <span class="gtd-badge gtd-opt">optional</span> |
-| `oncoplot_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/viralrecon/oncoplot_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `complex_heatmap_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `mosdepth/complex_heatmap_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `coverage_track_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `mosdepth/coverage_track_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `sankey_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/viralrecon/sankey_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `upset_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/viralrecon/upset_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
-| `variant_feature_matrix_canonical` | Table | <span class="gtd-badge gtd-transformed">transformed</span> | `nf-core/viralrecon/variant_feature_matrix_canonical.py` | <span class="gtd-badge gtd-opt">optional</span> |
+**Origin** tells you whether a collection is *real pipeline data* or a reshape of it: <span class="gtd-badge gtd-direct">direct</span> = a pipeline output (scanned, or a recipe that reads raw files); <span class="gtd-badge gtd-derived">derived</span> = a recipe that reshapes one or more *direct* collections into the layout a visualization needs (no new measurement). **Reads** shows what produces it: a <span class="gtd-badge gtd-recipe">recipe</span> `.py` transform, or a raw <span class="gtd-badge gtd-file">file</span> scanned off disk. (A `direct` collection can still have a recipe — one that merely parses/cleans the raw file; `derived` means the recipe reshapes another collection.)
+
+| Tag | Origin | Type | Reads | Status |
+|---|:--:|---|---|:--:|
+| `multiqc_data` | <span class="gtd-badge gtd-direct">direct</span> | <img src="https://raw.githubusercontent.com/MultiQC/logo/main/logos/multiqc_icon_color.svg" alt="MultiQC" width="14" style="vertical-align:text-bottom;"> MultiQC | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">multiqc/multiqc_data/multiqc.parquet</code> | <span class="gtd-badge gtd-req">required</span> |
+| `summary_metrics` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">multiqc/summary_metrics.py</code> | <span class="gtd-badge gtd-req">required</span> |
+| `variants_long` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">ivar/variants_long.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `pangolin_lineages` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">pangolin/pangolin_lineages.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `nextclade_results` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nextclade/nextclade_results.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `mosdepth_amplicon_coverage` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">variants/bowtie2/mosdepth/amplicon/all_samples.mosdepth.coverage.tsv</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `mosdepth_genome_coverage` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">variants/bowtie2/mosdepth/genome/all_samples.mosdepth.coverage.tsv</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `mosdepth_amplicon_heatmap` | <span class="gtd-badge gtd-direct">direct</span> | :material-table: Table | <span class="gtd-badge gtd-file">file</span> <code class="gtd-path">variants/bowtie2/mosdepth/amplicon/all_samples.mosdepth.heatmap.tsv</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `variant_oncoplot` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/viralrecon/oncoplot_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `amplicon_coverage_matrix` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">mosdepth/complex_heatmap_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `genome_coverage_track` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">mosdepth/coverage_track_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `classification_sankey` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/viralrecon/sankey_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `mutation_upset` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/viralrecon/upset_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
+| `variant_pca_matrix` | <span class="gtd-badge gtd-derived">derived</span> | :material-table: Table | <span class="gtd-badge gtd-recipe">recipe</span> <code class="gtd-path">nf-core/viralrecon/variant_feature_matrix_canonical.py</code> | <span class="gtd-badge gtd-opt">optional</span> |
 
 ### Conditional routes
 
-Rows are data collections; columns are the variables you set or `params.json` flags auto-detected from the run. Each filled cell is the effect of **setting** that variable; an **empty cell** means that variable leaves the collection unchanged. (4 collections are unaffected by any variable — present on every run.)
+Rows are data collections; columns are the variables you set or `params.json` flags auto-detected from the run. Each filled cell is the effect of **setting** that variable; an **empty cell** means that variable leaves the collection unchanged. (1 collections are unaffected by any variable — present on every run.)
 
 <p class="gtd-legend"><span class="gtd-badge gtd-plus-chip">+ included</span><span class="gtd-badge gtd-minus-chip">− removed</span><span class="gtd-badge gtd-swap-chip">⇄ repointed</span></p>
 
-<div class="gtd-mtx">
+<div class="gtd-mtx scroll">
 <table>
-<thead><tr><th class="dc">Data collection</th><th><code>IS_NANOPORE</code></th></tr></thead>
+<thead><tr><th class="dc">Data collection</th><th><code>PLATFORM=nanopore</code></th><th><code>VARIANT_CALLER=bcftools</code></th><th><code>PROTOCOL=metagenomic</code></th><th><code>SKIP_PANGOLIN=true</code></th><th><code>SKIP_NEXTCLADE=true</code></th><th><code>SKIP_VARIANTS_LONG_TABLE=true</code></th><th><code>SKIP_MOSDEPTH=true</code></th><th><code>SKIP_VARIANTS=true</code></th></tr></thead>
 <tbody>
-<tr><th class="dc"><code>summary_metrics</code></th><td class="minus" title="removed when IS_NANOPORE is set">−</td></tr>
-<tr><th class="dc"><code>variants_long</code></th><td class="minus" title="removed when IS_NANOPORE is set">−</td></tr>
-<tr><th class="dc"><code>pangolin_lineages</code></th><td class="swap" title="re-sourced when IS_NANOPORE is set">⇄</td></tr>
-<tr><th class="dc"><code>nextclade_results</code></th><td class="swap" title="re-sourced when IS_NANOPORE is set">⇄</td></tr>
-<tr><th class="dc"><code>mosdepth_amplicon_coverage</code></th><td class="swap" title="re-sourced when IS_NANOPORE is set">⇄</td></tr>
-<tr><th class="dc"><code>mosdepth_genome_coverage</code></th><td class="swap" title="re-sourced when IS_NANOPORE is set">⇄</td></tr>
-<tr><th class="dc"><code>mosdepth_amplicon_heatmap</code></th><td class="swap" title="re-sourced when IS_NANOPORE is set">⇄</td></tr>
-<tr><th class="dc"><code>oncoplot_canonical</code></th><td class="minus" title="removed when IS_NANOPORE is set">−</td></tr>
-<tr><th class="dc"><code>upset_canonical</code></th><td class="minus" title="removed when IS_NANOPORE is set">−</td></tr>
-<tr><th class="dc"><code>variant_feature_matrix_canonical</code></th><td class="minus" title="removed when IS_NANOPORE is set">−</td></tr>
+<tr><th class="dc"><code>summary_metrics</code></th><td class="minus" title="removed when PLATFORM=nanopore">−</td><td></td><td></td><td></td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>variants_long</code></th><td class="swap" title="re-sourced when PLATFORM=nanopore">⇄</td><td></td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_VARIANTS_LONG_TABLE=true">−</td><td></td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>pangolin_lineages</code></th><td class="swap" title="re-sourced when PLATFORM=nanopore">⇄</td><td class="swap" title="re-sourced when VARIANT_CALLER=bcftools">⇄</td><td></td><td class="minus" title="removed when SKIP_PANGOLIN=true">−</td><td></td><td></td><td></td><td></td></tr>
+<tr><th class="dc"><code>nextclade_results</code></th><td class="swap" title="re-sourced when PLATFORM=nanopore">⇄</td><td class="swap" title="re-sourced when VARIANT_CALLER=bcftools">⇄</td><td></td><td></td><td class="minus" title="removed when SKIP_NEXTCLADE=true">−</td><td></td><td></td><td></td></tr>
+<tr><th class="dc"><code>mosdepth_amplicon_coverage</code></th><td class="swap" title="re-sourced when PLATFORM=nanopore">⇄</td><td></td><td class="minus" title="removed when PROTOCOL=metagenomic">−</td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_MOSDEPTH=true">−</td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>mosdepth_genome_coverage</code></th><td class="swap" title="re-sourced when PLATFORM=nanopore">⇄</td><td></td><td></td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_MOSDEPTH=true">−</td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>mosdepth_amplicon_heatmap</code></th><td class="swap" title="re-sourced when PLATFORM=nanopore">⇄</td><td></td><td class="minus" title="removed when PROTOCOL=metagenomic">−</td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_MOSDEPTH=true">−</td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>variant_oncoplot</code></th><td></td><td></td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_VARIANTS_LONG_TABLE=true">−</td><td></td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>amplicon_coverage_matrix</code></th><td></td><td></td><td class="minus" title="removed when PROTOCOL=metagenomic">−</td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_MOSDEPTH=true">−</td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>genome_coverage_track</code></th><td></td><td></td><td></td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_MOSDEPTH=true">−</td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>classification_sankey</code></th><td></td><td></td><td></td><td class="minus" title="removed when SKIP_PANGOLIN=true">−</td><td class="minus" title="removed when SKIP_NEXTCLADE=true">−</td><td></td><td></td><td></td></tr>
+<tr><th class="dc"><code>mutation_upset</code></th><td></td><td></td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_VARIANTS_LONG_TABLE=true">−</td><td></td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
+<tr><th class="dc"><code>variant_pca_matrix</code></th><td></td><td></td><td></td><td></td><td></td><td class="minus" title="removed when SKIP_VARIANTS_LONG_TABLE=true">−</td><td></td><td class="minus" title="removed when SKIP_VARIANTS=true">−</td></tr>
 </tbody></table></div>
 
 ### Cross-DC links
@@ -125,6 +142,7 @@ Each recipe reshapes raw pipeline output into a tidy table. The name links to it
 
 | Recipe | Transforms | Output |
 |---|---|---|
+| [`artic/variants_long.py`](https://github.com/depictio/depictio/blob/main/depictio/catalog/artic/variants_long.py) | Parse ARTIC/clair3 (or medaka) nanopore per-sample VCFs into variants_long. | `sample`, `CHROM`, `POS`, `REF`, `ALT`, `AF`, `GENE`, `AA`, `EFFECT`, `FUNCLASS`, `mutation_label` |
 | [`ivar/variants_long.py`](https://github.com/depictio/depictio/blob/main/depictio/catalog/ivar/variants_long.py) | Clean and normalize viralrecon variants_long_table.csv for dashboard consumption. | `sample`, `CHROM`, `POS`, `REF`, `ALT`, `FILTER`, `DP`, `REF_DP`, `ALT_DP`, `AF`, `GENE`, `AA`, `EFFECT`, `FUNCLASS`, `mutation_label` |
 | [`mosdepth/complex_heatmap_canonical.py`](https://github.com/depictio/depictio/blob/main/depictio/catalog/mosdepth/complex_heatmap_canonical.py) | Canonical-schema ComplexHeatmap DC for viralrecon amplicon coverage. | `sample` |
 | [`mosdepth/coverage_track_canonical.py`](https://github.com/depictio/depictio/blob/main/depictio/catalog/mosdepth/coverage_track_canonical.py) | Canonical-schema Coverage Track DC for viralrecon. | `chromosome`, `position`, `value` |

--- a/docs/pipeline-templates/nf-core/ampliseq.md
+++ b/docs/pipeline-templates/nf-core/ampliseq.md
@@ -1,17 +1,23 @@
 ---
+title: Amplicon Sequencing
 hide:
   - navigation
 ---
 
-# nf-core/ampliseq
-
-<div style="display:flex;align-items:center;gap:16px;margin-bottom:16px;">
-  <img src="https://raw.githubusercontent.com/nf-core/ampliseq/master/docs/images/nf-core-ampliseq_logo_light.png" alt="nf-core/ampliseq" style="height:56px;" onerror="this.src='../../images/pipeline-templates/nf-core/ampliseq/nf-core-ampliseq_logo.png'">
-  <div style="flex:1;">
-    <strong style="font-size:1.1em;">Amplicon sequencing analysis workflow using DADA2 and QIIME2 — 16S, ITS, CO1, 18S and other amplicons across Illumina, PacBio, IonTorrent.</strong><br>
-    <span style="color:#666;font-size:0.9em;">nf-core pipeline · <a href="https://nf-co.re/ampliseq" target="_blank">nf-co.re/ampliseq</a></span>
+<div class="template-banner">
+  <a class="template-banner-logo" href="https://nf-co.re/ampliseq" target="_blank" title="nf-core/ampliseq on nf-co.re">
+    <img class="nf-core-dark" src="https://raw.githubusercontent.com/nf-core/ampliseq/master/docs/images/nf-core-ampliseq_logo_dark.png" alt="nf-core/ampliseq">
+    <img class="nf-core-light" src="https://raw.githubusercontent.com/nf-core/ampliseq/master/docs/images/nf-core-ampliseq_logo_light.png" alt="nf-core/ampliseq">
+  </a>
+  <div class="template-banner-body">
+    <h1 class="template-title">Amplicon Sequencing</h1>
+    <p class="template-subtitle">Amplicon sequencing analysis workflow using DADA2 and QIIME2 — 16S, ITS, CO1, 18S and other amplicons across Illumina, PacBio, IonTorrent.</p>
+    <p class="template-links">
+      <a href="https://nf-co.re/ampliseq" target="_blank"><i class="mdi mdi-open-in-new"></i> nf-co.re</a>
+      <a href="https://github.com/nf-core/ampliseq" target="_blank"><i class="mdi mdi-github"></i> GitHub</a>
+    </p>
   </div>
-  <div style="background:#2196F3;color:#fff;padding:4px 12px;border-radius:12px;font-size:0.85em;font-weight:600;white-space:nowrap;"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px;"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>Reviewed</div>
+  <span class="template-status-reviewed template-banner-badge" data-tooltip="Reviewed — tested, CI passes, and reviewed by the Depictio team or community."><i class="mdi mdi-check-circle-outline"></i> Reviewed</span>
 </div>
 
 The ampliseq template covers the main outputs of a standard nf-core/ampliseq run:
@@ -64,6 +70,8 @@ Running without `METADATA_FILE` prunes the metadata-dependent collections
     visualizations are dropped entirely, and the remaining components are re-packed so
     there are no empty rows. One template therefore covers 16S/ITS, single- vs.
     multi-region (SIDLE), and `skip_qiime` runs without edits.
+
+--8<-- "pipeline-templates/nf-core/_generated/ampliseq-2.16.0.md"
 
 ---
 

--- a/docs/pipeline-templates/nf-core/ampliseq.md
+++ b/docs/pipeline-templates/nf-core/ampliseq.md
@@ -58,7 +58,12 @@ Running without `METADATA_FILE` prunes the metadata-dependent collections
 (see the *Conditional routes* table); the `--skip_qiime` / `--skip_taxonomy`
 / multi-region routes are auto-detected from the run's `params.json`.
 
---8<-- "pipeline-templates/nf-core/_generated/ampliseq-2.16.0.md"
+!!! info "Self-adapting layout"
+    The dashboard adapts to whatever the run actually produced: components bound to
+    pruned or unparsed data collections are hidden, tabs left with no real
+    visualizations are dropped entirely, and the remaining components are re-packed so
+    there are no empty rows. One template therefore covers 16S/ITS, single- vs.
+    multi-region (SIDLE), and `skip_qiime` runs without edits.
 
 ---
 

--- a/docs/pipeline-templates/nf-core/index.md
+++ b/docs/pipeline-templates/nf-core/index.md
@@ -1,0 +1,13 @@
+---
+icon: simple/nfcore
+title: nf-core
+---
+
+# nf-core Templates
+
+Templates for [nf-core](https://nf-co.re) pipelines. Each template configures a complete Depictio project — data collections, recipes, dashboards, and cross-DC links — from a single `depictio-cli run` command.
+
+| Template | Pipeline | Versions |
+|----------|----------|---------- |
+| [ampliseq](ampliseq.md) | 16S / ITS / CO1 amplicon sequencing | 2.14.0, 2.16.0 |
+| [viralrecon](viralrecon.md) | Viral assembly and variant calling | 3.0.0 |

--- a/docs/pipeline-templates/nf-core/viralrecon.md
+++ b/docs/pipeline-templates/nf-core/viralrecon.md
@@ -23,7 +23,7 @@ hide:
 The viralrecon template covers the main outputs of a standard nf-core/viralrecon run:
 
 - :material-chart-bar: **MultiQC quality control** — FastQC, Cutadapt, samtools/picard alignment metrics
-- :material-dna: **Variant calling** — iVar variants with gene, effect, and allele-frequency annotations (illumina only)
+- :material-dna: **Variant calling** — gene, effect, and allele-frequency annotations from iVar (Illumina) or ARTIC/clair3 (nanopore)
 - :material-virus: **Lineage assignment** — Pangolin lineages with conflict and QC scores
 - :material-medical-bag: **Clade assignment** — Nextclade clades with substitution counts
 - :material-chart-line: **Coverage analysis** — Mosdepth amplicon coverage, genome coverage, and amplicon heatmap
@@ -39,37 +39,29 @@ The viralrecon template covers the main outputs of a standard nf-core/viralrecon
 
 ## Quick start
 
-viralrecon needs no extra template variables — the **same command** works for
-both sequencing platforms, which Depictio auto-detects from the run's
-`params.json`:
+`--data-root` is the only thing you have to pass. The template's routing variables
+(`PLATFORM`, `PROTOCOL`, `VARIANT_CALLER`, and the `SKIP_*` flags) mirror nf-core's own
+parameters and are **auto-derived from the run's `params.json`** — so the *same command*
+works for an Illumina or a nanopore run:
 
-=== "Illumina"
+```bash
+depictio run \
+  --template nf-core/viralrecon/3.0.0 \
+  --data-root /path/to/viralrecon_results
+```
 
-    ```bash
-    depictio run \
-      --template nf-core/viralrecon/3.0.0 \
-      --data-root /path/to/viralrecon_results
-    ```
+A nanopore run (whose `params.json` records `platform: nanopore`) is detected
+automatically: the coverage and lineage collections are repointed at the
+`artic_minion/` layout and the variant calls are **re-sourced** from the ARTIC
+`*.pass.vcf.gz` files — so the variant views (oncoplot, lollipop, manhattan) keep
+working. Only `summary_metrics` is dropped (no nanopore equivalent yet).
 
-    Full dashboard: MultiQC, coverage & depth, lineage & clustering, variants, sample QC.
-
-=== "Nanopore (ARTIC minion)"
-
-    ```bash
-    depictio run \
-      --template nf-core/viralrecon/3.0.0 \
-      --data-root /path/to/viralrecon_results
-    ```
-
-    `IS_NANOPORE` is auto-detected: the coverage and lineage collections are
-    repointed at the `artic_minion/` layout and the illumina-only variant
-    collections are dropped — see *Conditional routes* in the [Reference](#reference).
-
-!!! warning "`--variant_caller ivar` is required"
-    The viralrecon template's recipes hardcode paths under `variants/ivar/`
-    (see `variants_long.py`, `pangolin_lineages.py`, `nextclade_results.py`).
-    Running nf-core/viralrecon with the alternative `--variant_caller bcftools`
-    produces a different output layout that the template won't match.
+!!! tip "Override the auto-derived values"
+    The derivation reads `pipeline_info/params*.json`. Pass `--var NAME=value` to
+    override any of it — e.g. `--var PLATFORM=nanopore` when a `DATA_ROOT` aggregates
+    mixed-platform runs, or `--var SKIP_PANGOLIN=true` to force-drop a collection. Each
+    auto-derived value is logged at resolution time. See the full list and routes in the
+    [Reference](#reference).
 
 !!! tip "Aggregated data collections"
     The viralrecon DCs use `metatype: "Aggregated"`. They are built
@@ -81,10 +73,26 @@ both sequencing platforms, which Depictio auto-detects from the run's
 
 ## Reference
 
-Recipe DCs fan per-sample files into one delta table via `glob_pattern`; the
-`IS_NANOPORE` route (auto-detected from `params.json`) repoints
-coverage/lineage DCs at the `artic_minion/` layout and drops the
-illumina-only variant DCs.
+Recipe DCs fan per-sample files into one delta table via `glob_pattern`. The
+`PLATFORM=nanopore` route repoints the coverage/lineage DCs at the
+`artic_minion/` layout and re-sources `variants_long` from the ARTIC VCFs;
+only `summary_metrics` is dropped.
+
+### Direct vs derived data collections
+
+The template exposes two kinds of data collection, and the **Origin** column of the
+reference table below flags each one explicitly — so you can tell real measurements
+from views at a glance:
+
+| Origin | What it is | Examples |
+|---|---|---|
+| <span class="gtd-badge gtd-direct">direct</span> | A real pipeline output — scanned straight off disk, or lightly cleaned by a recipe that reads the raw files. This *is* the data. | `variants_long`, `pangolin_lineages`, `nextclade_results`, `mosdepth_amplicon_coverage` |
+| <span class="gtd-badge gtd-derived">derived</span> | A *reshape* of one or more direct collections into the exact column layout an advanced visualization needs — a view, not new measurement (its recipe reads another collection via `dc_ref`). | `variant_oncoplot`, `amplicon_coverage_matrix`, `genome_coverage_track`, `classification_sankey`, `mutation_upset`, `variant_pca_matrix` |
+
+Derived collections used to carry a `_canonical` suffix; they were renamed to
+say what they *produce* (e.g. `variant_feature_matrix_canonical` →
+`variant_pca_matrix`). Each one names its source recipe in the reference table's
+*Reads* column.
 
 !!! info "Self-adapting layout"
     The dashboard adapts to whatever the run actually produced: components bound to
@@ -148,7 +156,8 @@ filters propagate across tabs via cross-DC links on the
 
     - 4 summary cards: *Total Samples*, *Unique Lineages*, *Unique Clades*, *Avg Genome Coverage (10x)*
     - 6 figures: *Pangolin Lineage Distribution*, *Nextclade QC Status Overview*, *Nextclade Clade Distribution*, *Coverage vs Total Variants by Lineage*, *Genome Coverage per Sample (>= 10x Depth)*, *Nextclade — Substitutions vs Deletions by Clade*
-    - Sankey funnel: qc_status → lineage → clade (canonical sankey)
+    - Sankey funnel: qc_status → lineage → clade (`classification_sankey`)
+    - Variant-profile PCA embedding, coloured by lineage (`variant_pca_matrix`)
     - 3 tables: *Pangolin Lineage Assignments*, *Nextclade Clade Assignments*, *Summary Metrics*
 
 === "Variants"
@@ -163,9 +172,9 @@ filters propagate across tabs via cross-DC links on the
     **Components:**
 
     - 4 summary cards: *Total Variants*, *Unique Genes*, *Mean Allele Freq*, *Unique AA Changes*
-    - Manhattan plot: chr × pos × score (canonical manhattan)
-    - Lollipop: per-gene variants (canonical lollipop)
-    - Oncoplot: sample × gene × mutation_type (canonical oncoplot)
+    - Manhattan plot: chr × pos × score (bound directly to `variants_long`)
+    - Lollipop: per-gene variants (bound directly to `variants_long`)
+    - Oncoplot: sample × gene × mutation_type (`variant_oncoplot`)
     - 5 figures: *Allele Frequency vs Genome Position*, *Variant Count by Gene and Functional Class*, *Variant Effect Distribution*, *Variant Functional Class Distribution*, *Variant Count per Sample*
     - 1 table: *Variants Long Table*
 
@@ -182,7 +191,7 @@ filters propagate across tabs via cross-DC links on the
 
     - Summary cards: total samples, samples passing QC, mean coverage,
       mean variants per sample
-    - Sample × metric heatmap (canonical complex heatmap)
+    - Amplicon coverage matrix heatmap (`amplicon_coverage_matrix`)
     - Summary metrics table
 
 ---
@@ -207,13 +216,21 @@ depictio run --template nf-core/viralrecon/3.0.0 \
   --data-root results/
 ```
 
+A nanopore/ARTIC run (`nextflow … --platform nanopore`) needs no extra flags —
+Depictio reads `platform: nanopore` from the run's `params.json` and switches to the
+`artic_minion/` layout automatically.
+
 See [nf-co.re/viralrecon/usage](https://nf-co.re/viralrecon/3.0.0/docs/usage) for full pipeline documentation.
 
 ---
 
 ## Required data structure
 
-Point `--data-root` to the directory containing your viralrecon outputs. This can be a single run's `results/` folder or a parent directory containing multiple runs — Depictio scans recursively. Not all files are required; the template adapts to what's present and to the sequencing platform (`IS_NANOPORE` is auto-detected from the run's `params.json`).
+Point `--data-root` to the directory containing your viralrecon outputs. This can be a single run's `results/` folder or a parent directory containing multiple runs — Depictio scans recursively. Not all files are required; the template adapts to what's present and to the sequencing platform / caller / skip flags it reads from the run's `params.json` (override any with `--var`).
+
+The tree below shows the **Illumina** layout. On `PLATFORM=nanopore` the same
+collections are read from `artic_minion/` instead (coverage, lineage, and the
+ARTIC `*.pass.vcf.gz` variant calls).
 
 ```text
 <DATA_ROOT>/
@@ -222,12 +239,12 @@ Point `--data-root` to the directory containing your viralrecon outputs. This ca
 │   │   └── multiqc.parquet
 │   └── summary_variants_metrics_mqc.csv
 └── variants/
-    └── ivar/                                   # illumina layout (⚠ artic_minion/ on nanopore)
+    └── ivar/                                   # Illumina layout (artic_minion/ on PLATFORM=nanopore)
         ├── consensus/
         │   └── bcftools/
         │       ├── pangolin/*.pangolin.csv     # Pangolin lineage, one file per sample
         │       └── nextclade/*.csv             # Nextclade clade, one file per sample
-        ├── variants_long_table.csv             # ⚠ illumina only (dropped on nanopore)
+        ├── variants_long_table.csv             # Illumina variant calls (ARTIC *.pass.vcf.gz on nanopore)
         └── *.mosdepth.{coverage,heatmap}.tsv   # amplicon / genome coverage
 ```
 

--- a/docs/pipeline-templates/nf-core/viralrecon.md
+++ b/docs/pipeline-templates/nf-core/viralrecon.md
@@ -1,17 +1,23 @@
 ---
+title: Viral Genome Reconstruction
 hide:
   - navigation
 ---
 
-# nf-core/viralrecon
-
-<div style="display:flex;align-items:center;gap:16px;margin-bottom:16px;">
-  <img src="https://raw.githubusercontent.com/nf-core/viralrecon/master/docs/images/nf-core-viralrecon_logo_light.png" alt="nf-core/viralrecon" style="height:56px;" onerror="this.src='../../images/pipeline-templates/nf-core/viralrecon/nf-core-viralrecon_logo.png'">
-  <div style="flex:1;">
-    <strong style="font-size:1.1em;">Assembly and intrahost/low-frequency variant calling for viral samples — SARS-CoV-2 + other viral genomes via the reference-genomes config.</strong><br>
-    <span style="color:#666;font-size:0.9em;">nf-core pipeline · <a href="https://nf-co.re/viralrecon" target="_blank">nf-co.re/viralrecon</a></span>
+<div class="template-banner">
+  <a class="template-banner-logo" href="https://nf-co.re/viralrecon" target="_blank" title="nf-core/viralrecon on nf-co.re">
+    <img class="nf-core-dark" src="https://raw.githubusercontent.com/nf-core/viralrecon/master/docs/images/nf-core-viralrecon_logo_dark.png" alt="nf-core/viralrecon">
+    <img class="nf-core-light" src="https://raw.githubusercontent.com/nf-core/viralrecon/master/docs/images/nf-core-viralrecon_logo_light.png" alt="nf-core/viralrecon">
+  </a>
+  <div class="template-banner-body">
+    <h1 class="template-title">Viral Genome Reconstruction</h1>
+    <p class="template-subtitle">Assembly and intrahost/low-frequency variant calling for viral samples — SARS-CoV-2 + other viral genomes via the reference-genomes config.</p>
+    <p class="template-links">
+      <a href="https://nf-co.re/viralrecon" target="_blank"><i class="mdi mdi-open-in-new"></i> nf-co.re</a>
+      <a href="https://github.com/nf-core/viralrecon" target="_blank"><i class="mdi mdi-github"></i> GitHub</a>
+    </p>
   </div>
-  <div style="background:#2196F3;color:#fff;padding:4px 12px;border-radius:12px;font-size:0.85em;font-weight:600;white-space:nowrap;"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px;"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>Reviewed</div>
+  <span class="template-status-reviewed template-banner-badge" data-tooltip="Reviewed — tested, CI passes, and reviewed by the Depictio team or community."><i class="mdi mdi-check-circle-outline"></i> Reviewed</span>
 </div>
 
 The viralrecon template covers the main outputs of a standard nf-core/viralrecon run:
@@ -85,6 +91,8 @@ illumina-only variant DCs.
     pruned or unparsed data collections are hidden, tabs left with no real
     visualizations are dropped, and the rest are re-packed with no empty rows. One
     template therefore covers both the Illumina and nanopore/ARTIC routes without edits.
+
+--8<-- "pipeline-templates/nf-core/_generated/viralrecon-3.0.0.md"
 
 ---
 

--- a/docs/pipeline-templates/nf-core/viralrecon.md
+++ b/docs/pipeline-templates/nf-core/viralrecon.md
@@ -80,7 +80,11 @@ Recipe DCs fan per-sample files into one delta table via `glob_pattern`; the
 coverage/lineage DCs at the `artic_minion/` layout and drops the
 illumina-only variant DCs.
 
---8<-- "pipeline-templates/nf-core/_generated/viralrecon-3.0.0.md"
+!!! info "Self-adapting layout"
+    The dashboard adapts to whatever the run actually produced: components bound to
+    pruned or unparsed data collections are hidden, tabs left with no real
+    visualizations are dropped, and the rest are re-packed with no empty rows. One
+    template therefore covers both the Illumina and nanopore/ARTIC routes without edits.
 
 ---
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1112,3 +1112,286 @@ body.catalog-fs-lock .md-main {
 .cat-card { color: #9966CC; }     /* purple */
 .cat-advviz { color: #7A5DC7; }   /* violet */
 .cat-multiqc { color: #8BC34A; }  /* green */
+
+/* ── Template cards ─────────────────────────────────────────────────── */
+
+.template-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin: 16px 0 24px;
+}
+
+@media (max-width: 76.1875em) {
+  .template-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 44.9375em) {
+  .template-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.template-card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none !important;
+  color: inherit;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.template-card:hover {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14);
+  transform: translateY(-3px);
+}
+
+.template-card-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 22px 20px;
+  min-height: 90px;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+[data-md-color-scheme="default"] .template-card-logo {
+  background: var(--md-code-bg-color);
+}
+
+[data-md-color-scheme="slate"] .template-card-logo {
+  background: #111e2b;
+}
+
+.template-card-logo img {
+  max-height: 52px;
+  max-width: 180px;
+  object-fit: contain;
+}
+
+.template-card-body {
+  padding: 14px 16px 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.template-card-desc {
+  margin: 0;
+  font-size: 0.82em;
+  line-height: 1.5;
+  color: var(--md-default-fg-color--light);
+}
+
+.template-card-meta {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.template-version {
+  background: #e8f5e9;
+  color: #1b5e20;
+  border: 1px solid #a5d6a7;
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 0.78em;
+  font-weight: 600;
+  font-family: var(--md-code-font-family);
+  letter-spacing: 0.02em;
+}
+
+[data-md-color-scheme="slate"] .template-version {
+  background: #152b18;
+  color: #81c784;
+  border-color: #2e5d33;
+}
+
+.template-status-reviewed {
+  background: #e3f2fd;
+  color: #0d47a1;
+  border: 1px solid #90caf9;
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 0.78em;
+  font-weight: 600;
+}
+
+[data-md-color-scheme="slate"] .template-status-reviewed {
+  background: #0d2137;
+  color: #64b5f6;
+  border-color: #1565c0;
+}
+
+/* ── Status level cards ─────────────────────────────────────────────── */
+
+.status-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin: 16px 0 24px;
+}
+
+@media (max-width: 44.9375em) {
+  .status-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.status-card {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.status-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-icon {
+  font-size: 1.4em;
+  line-height: 1;
+}
+
+.status-title {
+  font-weight: 700;
+  font-size: 0.95em;
+}
+
+.status-desc {
+  margin: 0;
+  font-size: 0.82em;
+  color: var(--md-default-fg-color--light);
+  line-height: 1.5;
+}
+
+.status-certified  { border-top: 3px solid #4CAF50; }
+.status-certified  .status-icon { color: #4CAF50; }
+
+.status-reviewed   { border-top: 3px solid #2196F3; }
+.status-reviewed   .status-icon { color: #2196F3; }
+
+.status-experimental { border-top: 3px solid #FF9800; }
+.status-experimental .status-icon { color: #FF9800; }
+
+/* ── Individual template page banner (tinted card) ── */
+.template-banner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 22px;
+  align-items: center;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 10px;
+  padding: 18px 22px;
+  margin: 8px 0 22px;
+}
+.template-banner-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none !important;
+}
+.template-banner-logo img {
+  max-height: 72px;
+  max-width: 240px;
+  object-fit: contain;
+}
+.template-banner-body { min-width: 0; }
+
+/* Title: standard font (override the site-wide Virgil h1), compact in the banner */
+.md-typeset .template-banner-body h1.template-title {
+  font-family: var(--md-text-font-family), -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif !important;
+  font-size: 1.55em;
+  margin: 0 0 4px;
+}
+/* Subtitle: highlighted */
+.template-banner-body .template-subtitle {
+  font-size: 1.05em;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0 0 8px;
+}
+/* Compact icon links (no chip border) */
+.template-links {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin: 0;
+}
+.template-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.85em;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--md-primary-fg-color);
+}
+.template-links a:hover { text-decoration: underline; }
+.template-links .mdi { font-size: 1.15em; }
+
+/* Reviewed pill — own column, vertically centered (via the grid's align-items) */
+.template-status-reviewed.template-banner-badge {
+  position: relative;
+  justify-self: end;
+  white-space: nowrap;
+  font-size: 0.95em;
+  padding: 7px 16px;
+  border-radius: 8px;
+  cursor: help;
+}
+.template-banner-badge .mdi { vertical-align: -2px; margin-right: 5px; font-size: 1.15em; }
+
+/* Custom tooltip for the Reviewed badge — bigger, short delay, help cursor */
+.template-banner-badge::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: max-content;
+  max-width: 300px;
+  white-space: normal;
+  text-align: left;
+  font-size: 0.82rem;
+  font-weight: 400;
+  line-height: 1.45;
+  color: var(--md-default-bg-color);
+  background: var(--md-default-fg-color);
+  padding: 9px 13px;
+  border-radius: 6px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.22);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-3px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  transition-delay: 0s;
+  pointer-events: none;
+  z-index: 20;
+}
+.template-banner-badge:hover::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  transition-delay: 0.15s;
+}
+
+@media (max-width: 44.9375em) {
+  .template-banner {
+    grid-template-columns: 1fr;
+    gap: 14px;
+    padding: 16px 18px;
+  }
+  .template-banner-badge { justify-self: start; }
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1055,6 +1055,17 @@ body.catalog-fs-lock .md-main {
 .module-flow__step > :first-child { margin-top: 0; }
 .module-flow__step > :last-child { margin-bottom: 0; }
 
+/* Vertically center the (enlarged) icon with its bold label on the step's
+   first line — applies to both the intro and how-it-works triptychs. */
+.module-flow__step > p:first-child {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+.module-flow__step > p:first-child .twemoji {
+    flex: 0 0 auto;
+}
+
 /* Intro mapping (file -> module -> visualization) and how-it-works steps
    (detect -> reshape -> render) share the same positional accent colors. */
 .module-flow__step--detect,

--- a/docs/usage/guides/web_ui.md
+++ b/docs/usage/guides/web_ui.md
@@ -41,6 +41,10 @@ If you have configured Google OAuth for your Depictio instance (see [Configurati
     </a>
 </div>
 
+Each dashboard is shown as a card. Cards display the dashboard's screenshot thumbnail
+once one has been captured, and fall back to the dashboard's logo (when set) before the
+generic placeholder.
+
 ### <span style="color: #7A5DC7;">:material-menu:</span> Sidebar Navigation
 
 The left sidebar provides easy access to various sections of the application. This includes:
@@ -169,9 +173,9 @@ The **About** section provides information about the GitHub repository and the d
 
 The **Admin** section is only accessible to users with admin privileges. It allows admins to view users, projects and dashboards. The **Users** tab displays a list/delete/change status (sysadmin/standard) of all users registered in the system. The **Dashboards** tab displays a list of all dashboards while the **Projects** tab lists all projects. Admins can delete any project or dashboard, regardless of ownership.
 
-## <span style="color: #45B8AC;">:material-react:</span> React viewer — additional pages
+## <span style="color: #45B8AC;">:material-sitemap:</span> Page reference
 
-These pages are part of the React viewer (v1.0.0+) and surface project-detail UI and the CLI-agents panel.
+Depictio's main pages and their URLs:
 
 ### <span style="color: #45B8AC;">:material-folder-multiple:</span> Projects list (/projects)
 
@@ -183,7 +187,15 @@ These pages are part of the React viewer (v1.0.0+) and surface project-detail UI
 
 ### <span style="color: #45B8AC;">:material-database-cog:</span> Project detail (/projects/{id})
 
-Data collections, cross-DC links, and the joins graph for a single project.
+A single project's data, organised into tabs:
+
+- **Overview** — project summary and metadata.
+- **Data Collections** — a sortable, filterable table of the project's data collections.
+- **Links** — cross-DC links and the joins graph, with sortable/filterable columns.
+- **Ingestion** — for projects created from a [pipeline template](../../pipeline-templates/README.md), the [ingestion report](../../features/dashboards.md#ingestion-report-health) of expected vs. ingested data collections.
+
+You can reach this page directly by clicking the **project badge** shown on any
+dashboard card or in the dashboards table.
 
 <div style="border: 1px solid grey; width: 602px; padding: 1px;">
     <a href="../../../images/v0.12/react-beta/page_project_detail.png" target="_blank">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -227,6 +227,7 @@ nav:
           - YAML Dashboard Sync: features/yaml-sync.md
       - System Design:
           - Architecture: features/architecture.md
+          - Performance & Scaling: features/performance.md
           - Data Model: features/data-model.md
           - Security: features/security.md
   - API:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,6 +239,7 @@ nav:
   - Templates:
       - pipeline-templates/README.md
       - nf-core:
+          - pipeline-templates/nf-core/index.md
           - ampliseq: pipeline-templates/nf-core/ampliseq.md
           - viralrecon: pipeline-templates/nf-core/viralrecon.md
   - Modules: modules/index.md


### PR DESCRIPTION
Adds the **v1.1.0** changelog entry and closes the documentation gaps it surfaced.

## Changelog
New `v1.1.0 (unreleased)` section in `docs/changelog/README.md`:
- **New Features** — self-adapting nf-core templates, ingestion report, component catalog, `depictio-cli run --dashboard-name`, `DEPICTIO_SEED_PROJECTS`
- **Performance** — rendering & caching work (column projection, adaptive offload, Polars-native figures, Arrow/LZ4 cache, scatter downsampling); flagged as *not yet extensively benchmarked*
- **Improvements** — project-detail tabs, dashboard logo thumbnail, Codespaces boot
- **Bug Fixes** — FastQC alpha colors, empty heatmap categories, unparsed MultiQC modules, viralrecon coverage cards

## New / updated pages
- **new** `features/performance.md` (+ System Design nav) — render/cache mechanisms, offload settings, tuning; "work in progress / not yet benchmarked" note
- `features/dashboards.md` — Ingestion Report & Health section (color-coded statuses + health banner)
- `depictio-cli/usage.md` — `--dashboard-name`, Catalog Commands, recipe heading emoji (TOC-safe)
- `installation/env-reference.md` — `DEPICTIO_SEED_PROJECTS`; `installation/README.md` — Codespaces note
- `pipeline-templates/nf-core/{ampliseq,viralrecon}.md` — self-adapting layout notes
- `usage/guides/web_ui.md` — project-detail tabs/badges, dashboard logo; de-React'd "Page reference" section
- `stylesheets/extra.css` — module-flow triptych icon alignment

## Notes
- Release date left as `(unreleased)` — to fill when v1.1.0 is tagged.
- Branch rebased on latest `main` (includes the merged Depictio Modules page).